### PR TITLE
LIBDRUM-654. Add UMD header.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,6 @@
 
 <body>
   <ds-app></ds-app>
-  <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=1&amp;support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&amp;wrapper=1160&amp;sticky=0"></script>
 </body>
 
 <!-- do not include client bundle, it is injected with Zone already loaded -->

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,7 @@
 
 <body>
   <ds-app></ds-app>
+  <script src="https://umd-header.umd.edu/build/bundle.js?search=0&amp;search_domain=&amp;events=0&amp;news=0&amp;schools=0&amp;admissions=0&amp;support=1&amp;support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&amp;wrapper=1160&amp;sticky=0"></script>
 </body>
 
 <!-- do not include client bundle, it is injected with Zone already loaded -->

--- a/src/themes/drum/app/header/header.component.html
+++ b/src/themes/drum/app/header/header.component.html
@@ -1,3 +1,4 @@
+<ds-umd-header></ds-umd-header>
 <ds-umd-environment-banner></ds-umd-environment-banner>
 <header class="header">
   <nav role="navigation" [attr.aria-label]="'nav.user.description' | translate" class="container navbar navbar-expand-md px-0">

--- a/src/themes/drum/app/umd-header/umd-header.component.ts
+++ b/src/themes/drum/app/umd-header/umd-header.component.ts
@@ -1,0 +1,21 @@
+import {Component, OnInit} from '@angular/core';
+
+/**
+ * Simple component to inject the standard UMD header banner. Adds a <script>
+ * element to the end of the document body to dynamically load the remote script
+ * to generate the banner.
+ *
+ * Based on code at https://stackoverflow.com/a/38473334
+ */
+@Component({
+  selector: 'ds-umd-header',
+  template: '',
+})
+export class UmdHeaderComponent implements OnInit {
+  ngOnInit() {
+    const url = 'https://umd-header.umd.edu/build/bundle.js?search=0&search_domain=&events=0&news=0&schools=0&admissions=0&support=1&support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&wrapper=1160&sticky=0';
+    const node = document.createElement('script');
+    node.src = url;
+    document.body.appendChild(node);
+  }
+}

--- a/src/themes/drum/theme.module.ts
+++ b/src/themes/drum/theme.module.ts
@@ -5,11 +5,13 @@ import { SharedModule } from '../../app/shared/shared.module';
 import { HeaderComponent } from './app/header/header.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
 import { UmdEnvironmentBannerComponent } from './app/umd-environment-banner/umd-environment-banner.component';
+import {UmdHeaderComponent} from './app/umd-header/umd-header.component';
 
 const DECLARATIONS = [
   HeaderComponent,
   NavbarComponent,
-  UmdEnvironmentBannerComponent
+  UmdEnvironmentBannerComponent,
+  UmdHeaderComponent
 ];
 
 @NgModule({


### PR DESCRIPTION
~Include the script embed for the UMD header banner in the top-level HTML index template.~

Create a ds-umd-header component that injects the script tag to render the UMD header banner.

https://issues.umd.edu/browse/LIBDRUM-654