### PR TITLE
LIBDRUM-655. Add environment banners

### DIFF
--- a/README-DRUM.md
+++ b/README-DRUM.md
@@ -71,3 +71,50 @@ The original dspace-angular documentation:
     watch for changes, rebuild the code, and reload the server for you.
 
     Then go to [http://localhost:4000] in your browser
+
+## Customizations
+
+### Environment Banner
+
+In keeping with [SSDR policy](https://confluence.umd.edu/display/LIB/Create+Environment+Banners),
+an "environment banner" will be displayed at the top of each page when running
+on non-production servers.
+
+There are two ways to configure the environment banner:
+
+### YAML format
+
+The following is an example of configuring in a "config/config.*.yml" YAML file,
+such as "config/config.dev.yml":
+
+```yaml
+# UMD Environment Banner settings
+environmentBanner:
+  text: Local Development
+  foregroundColor: "#fff"
+  backgroundColor: "#008000"
+  enabled: true
+```
+
+In DSpace, the configuration from the YAML files can be overridden using either
+environment variables, or a ".env" file (see the "Configuration Override"
+section in <https://wiki.lyrasis.org/display/DSDOC7x/User+Interface+Configuration>.
+
+The following environment variables can be used:
+
+- DSPACE_ENVIRONMENTBANNER_TEXT - the text to display in the banner
+- DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR - the foreground color for the
+  banner, as a CSS color
+- DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR - the background color for the
+  banner, as a CSS color
+- DSPACE_ENVIRONMENTBANNER_ENABLED - "true" (case-sensitive) enables the banner.
+  Anything else (including not being provied, or blank) disables the banner.
+
+For example, in a ".env" file:
+
+```text
+DSPACE_ENVIRONMENTBANNER_TEXT=Test Environment
+DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR=#000
+DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR=#fff100
+DSPACE_ENVIRONMENTBANNER_ENABLED=true
+```

--- a/README-DRUM.md
+++ b/README-DRUM.md
@@ -45,6 +45,12 @@ The original dspace-angular documentation:
       port: 8080
       nameSpace: /server
 
+    # UMD Environment Banner settings
+    environmentBanner:
+      text: Local Development
+      foregroundColor: "#fff"
+      backgroundColor: "#008000"
+      enabled: true
     EOF
     ```
 

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -10,6 +10,10 @@ import { ServerConfig } from './server-config.interface';
 import { mergeConfig } from './config.util';
 import { isNotEmpty } from '../app/shared/empty.util';
 
+// Require "dotenv" package, so ".env" files in the root project directory
+// will be picked up.
+require('dotenv').config();
+
 const CONFIG_PATH = join(process.cwd(), 'config');
 
 type Environment = 'production' | 'development' | 'test';

--- a/src/themes/drum/app/header/header.component.html
+++ b/src/themes/drum/app/header/header.component.html
@@ -1,3 +1,4 @@
+<ds-umd-environment-banner></ds-umd-environment-banner>
 <header class="header">
   <nav role="navigation" [attr.aria-label]="'nav.user.description' | translate" class="container navbar navbar-expand-md px-0">
     <div class="d-flex flex-grow-1">

--- a/src/themes/drum/app/umd-environment-banner/umd-environment-banner.component.html
+++ b/src/themes/drum/app/umd-environment-banner/umd-environment-banner.component.html
@@ -1,0 +1,1 @@
+<div [style]="bannerStyle" *ngIf="bannerEnabled">{{ bannerText }}</div>

--- a/src/themes/drum/app/umd-environment-banner/umd-environment-banner.component.ts
+++ b/src/themes/drum/app/umd-environment-banner/umd-environment-banner.component.ts
@@ -1,0 +1,24 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { AppConfig, APP_CONFIG } from 'src/config/app-config.interface';
+@Component({
+  selector: 'ds-umd-environment-banner',
+  templateUrl: './umd-environment-banner.component.html',
+  styleUrls: ['./umd-environment-banner.component.scss']
+})
+export class UmdEnvironmentBannerComponent implements OnInit {
+  bannerText: string = '';
+  bannerEnabled = false;
+  bannerStyle = {};
+
+  constructor(@Inject(APP_CONFIG) private appConfig: AppConfig) {
+  }
+
+  ngOnInit(): void {
+    let bannerConfig = this.appConfig['environmentBanner'];
+
+    this.bannerText = bannerConfig.text
+    this.bannerEnabled = bannerConfig.enabled;
+
+    this.bannerStyle = { 'color': bannerConfig.foregroundColor, 'background-color': bannerConfig.backgroundColor };
+  }
+}

--- a/src/themes/drum/theme.module.ts
+++ b/src/themes/drum/theme.module.ts
@@ -4,10 +4,12 @@ import { NavbarModule } from '../../app/navbar/navbar.module';
 import { SharedModule } from '../../app/shared/shared.module';
 import { HeaderComponent } from './app/header/header.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
+import { UmdEnvironmentBannerComponent } from './app/umd-environment-banner/umd-environment-banner.component';
 
 const DECLARATIONS = [
   HeaderComponent,
-  NavbarComponent
+  NavbarComponent,
+  UmdEnvironmentBannerComponent
 ];
 
 @NgModule({


### PR DESCRIPTION
h3. Environment Banner Implementation

Instead of directly porting the DRUM 6 environment configuration to DSpace 7, used the lessons learned from the "umd_lib_style" project, where it proved to be easier and more flexible to simply specify all the necessary banner parameters directly:

In a "config/config.*.yml" file:

{noformat}
    environmentBanner:
      text: Local Development
      foregroundColor: "#fff"
      backgroundColor: "#008000"
      enabled: true
{noformat}

In an ".env" file, or via environment variables:

* DSPACE_ENVIRONMENTBANNER_TEXT
* DSPACE_ENVIRONMENTBANNER_FOREGROUNDCOLOR="#000"
* DSPACE_ENVIRONMENTBANNER_BACKGROUNDCOLOR="#d2b48c"
* DSPACE_ENVIRONMENTBANNER_ENABLED=true

h3. ".env" Loading Issue

According to the DSpace 7 documentation at

https://wiki.lyrasis.org/display/DSDOC7x/User+Interface+Configuration,

values in an ".env" file located at the project root should be used as part of the environment configuration, if such a file exists. Testing, however, was unsuccessful in getting this to work. There is a "dotenv" package (https://github.com/motdotla/dotenv) in the "package.json", but it doesn't seem to be used anywhere. The instructions for the "dotenv" package indicate that to use it there should be the line:

{noformat}
require('dotenv').config() 
{noformat}

In DSpace 7.1, the above line was in "scripts/set-env.ts", but that file doesn't exist in DSpace 7.2. Placing the line at the top of the "src/config/config.server.ts" file (just below the imports), enables the ".env" file to work as indicated in the documentation.

https://issues.umd.edu/browse/LIBDRUM-655