### PR TITLE
LIBDRUM-654. Ensure UMD header only gets added once.

### DIFF
--- a/src/themes/drum/app/umd-header/umd-header.component.ts
+++ b/src/themes/drum/app/umd-header/umd-header.component.ts
@@ -14,8 +14,11 @@ import {Component, OnInit} from '@angular/core';
 export class UmdHeaderComponent implements OnInit {
   ngOnInit() {
     const url = 'https://umd-header.umd.edu/build/bundle.js?search=0&search_domain=&events=0&news=0&schools=0&admissions=0&support=1&support_url=https%253A%252F%252Fgiving.umd.edu%252Fgiving%252FshowSchool.php%253Fname%253Dlibraries&wrapper=1160&sticky=0';
-    const node = document.createElement('script');
-    node.src = url;
-    document.body.appendChild(node);
+    // check for an existing #umdheader-main element, so we only add the header once
+    if (document.getElementById('umdheader-main') === null) {
+      const node = document.createElement('script');
+      node.src = url;
+      document.body.appendChild(node);
+    }
   }
 }


### PR DESCRIPTION
Check for an existing #umdheader-main element before inserting the script tag, so we only add the header once.

https://issues.umd.edu/browse/LIBDRUM-654