### PR TITLE
LIBDRUM-694. Push notifications below UMD campus banner

### DIFF
--- a/src/themes/drum/styles/_global-styles.scss
+++ b/src/themes/drum/styles/_global-styles.scss
@@ -2,3 +2,17 @@
 @import '../../dspace/styles/global-styles.scss';
 
 // Customizations for "drum" theme
+
+:root {
+  // The height of the campus-provided UMD banner, in pixels
+  --umd-ds-umd-campus-banner-height: 44px;
+}
+
+// LIBDRUM-694 - Add "margin-top" to notifications-wrapper defined in
+// src/app/shared/notifications/notifications-board/notifications-board.component.scss
+// in order to push notifications appearing in the upper-right corner of the
+// page down far enough that the timer bar and "Close" button will not be
+// obscured by the UMD campus banner
+.notifications-wrapper.top {
+  margin-top: var(--umd-ds-umd-campus-banner-height);
+}


### PR DESCRIPTION
Adjusted the top margin of the "notifications-wrapper" used to present notifications, so that the top edge of notifications are no longer obscured by the UMD campus banner.

https://issues.umd.edu/browse/LIBDRUM-694
