### PR TITLE
LIBDRUM-666. Add PRESERVATION to list of standard bundles

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -17,3 +17,7 @@ themes:
         href: assets/drum/images/favicons/favicon.ico
         sizes: any
   - name: 'dspace'
+
+# LIBDRUM-666 - Add PRESERVATION to default standard bundles list
+bundle:
+  standardBundles: [ ORIGINAL, THUMBNAIL, LICENSE, PRESERVATION ]


### PR DESCRIPTION
Modified the "standardBundles" list in "config/config.yml" to add the PRESERVATION bundle type.

https://issues.umd.edu/browse/LIBDRUM-666

