### PR TITLE
LIBDRUM-660. Added "UM Directory Information" section to EPerson form

### DIFF
--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -81,4 +81,35 @@
               class="btn btn-primary">{{messagePrefix + '.goToGroups' | translate}}</button>
     </div>
   </div>
+
+  <!-- UMD Customization for LIBDRUM-660 --->
+  <ng-container *ngVar="(ldap | async) as ldapRD">
+    <div *ngIf="ldapRD.hasSucceeded && !ldapRD.hasNoContent">
+      <h3>{{ messagePrefix + '.ldap.title' | translate }}</h3>
+      <ul>
+        <li>{{messagePrefix + '.ldap.name' | translate}} {{ ldapRD.payload.lastName }}, {{ ldapRD.payload.firstName }}</li>
+        <li>{{messagePrefix + '.ldap.email' | translate}} {{ ldapRD.payload.email }}</li>
+        <li>{{messagePrefix + '.ldap.phone' | translate}} {{ ldapRD.payload.phone }}</li>
+        <li>{{messagePrefix + '.ldap.faculty' | translate}} {{ ldapRD.payload.isFaculty }}</li>
+        <li>{{messagePrefix + '.ldap.umAppointment' | translate}}
+          <ul>
+            <li *ngFor="let umAppt of ldapRD.payload.umAppointments">
+              {{ umAppt }}
+            </li>
+          </ul>
+        </li>
+        <div *ngIf="ldapRD.payload.groups.length > 0">
+          <li>{{messagePrefix + '.ldap.groups' | translate}}</li>
+          <ul>
+            <li *ngFor="let group of ldapRD.payload.groups">
+              <a (click)="groupsDataService.startEditingNewGroup(group)"
+                [routerLink]="[groupsDataService.getGroupEditPageRouterLink(group)]">{{ group.name }}</a>
+            </li>
+          </ul>
+        </div>
+      </ul>
+    </div>
+  </ng-container>
+  <!-- End UMD Customization for LIBDRUM-660 -->
+
 </div>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -24,6 +24,10 @@ import { AuthService } from '../../../core/auth/auth.service';
 import { AuthServiceStub } from '../../../shared/testing/auth-service.stub';
 import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
+// UMD Customization for LIBDRUM-660
+import { LdapDataServiceStub } from '../../../shared/testing/ldap-data-service.stub';
+import { LdapDataService } from 'src/app/core/eperson/ldap-data.service';
+// End UMD Customization for LIBDRUM-660
 import { createPaginatedList } from '../../../shared/testing/utils.test';
 import { RequestService } from '../../../core/data/request.service';
 import { PaginationService } from '../../../core/pagination/pagination.service';
@@ -42,6 +46,9 @@ describe('EPersonFormComponent', () => {
   let authService: AuthServiceStub;
   let authorizationService: AuthorizationDataService;
   let groupsDataService: GroupDataService;
+  // UMD Customization for LIBDRUM-660
+  let ldapDataService: LdapDataServiceStub;
+  // End UMD Customization for LIBDRUM-660
   let epersonRegistrationService: EpersonRegistrationService;
 
   let paginationService;
@@ -195,6 +202,9 @@ describe('EPersonFormComponent', () => {
       providers: [
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: GroupDataService, useValue: groupsDataService },
+        // UMD Customization for LIBDRUM-660
+        { provide: LdapDataService, useValue: LdapDataServiceStub },
+        // End UMD Customization for LIBDRUM-660
         { provide: FormBuilderService, useValue: builderService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },
         { provide: AuthService, useValue: authService },

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.ts
@@ -13,6 +13,10 @@ import { PaginatedList } from '../../../core/data/paginated-list.model';
 import { RemoteData } from '../../../core/data/remote-data';
 import { EPersonDataService } from '../../../core/eperson/eperson-data.service';
 import { GroupDataService } from '../../../core/eperson/group-data.service';
+// UMD Customization for LIBDRUM-660
+import { LdapDataService } from '../../../core/eperson/ldap-data.service';
+import { Ldap } from '../../../core/eperson/models/ldap.model';
+// End UMD Customization for LIBDRUM-660
 import { EPerson } from '../../../core/eperson/models/eperson.model';
 import { Group } from '../../../core/eperson/models/group.model';
 import {
@@ -145,6 +149,13 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
    */
   groups: Observable<RemoteData<PaginatedList<Group>>>;
 
+  // UMD Customization for LIBDRUM-660
+  /**
+   * LDAP information associated with this EPerson
+   */
+  ldap: Observable<RemoteData<Ldap | NoContent>>;
+  // End UMD Customization for LIBDRUM-660
+
   /**
    * Pagination config used to display the list of groups
    */
@@ -173,6 +184,9 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
     protected changeDetectorRef: ChangeDetectorRef,
     public epersonService: EPersonDataService,
     public groupsDataService: GroupDataService,
+    // UMD Customization for LIBDRUM-660
+    public ldapDataService: LdapDataService,
+    // End UMD Customization for LIBDRUM-660
     private formBuilderService: FormBuilderService,
     private translateService: TranslateService,
     private notificationsService: NotificationsService,
@@ -302,6 +316,18 @@ export class EPersonFormComponent implements OnInit, OnDestroy {
           return observableOf(undefined);
         })
       );
+
+      // UMD Customization for LIBDRUM-660
+      this.ldap = activeEPerson$.pipe(
+        switchMap((eperson) => {
+          if (eperson != null) {
+            let result = this.ldapDataService.getLdap(eperson, true, true);
+            return result;
+          }
+          return observableOf(undefined);
+        })
+      );
+      // End UMD Customization for LIBDRUM-660
 
       this.canImpersonate$ = activeEPerson$.pipe(
         switchMap((eperson) => {

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -67,6 +67,10 @@ import { DspaceRestService } from './dspace-rest/dspace-rest.service';
 import { EPersonDataService } from './eperson/eperson-data.service';
 import { EPerson } from './eperson/models/eperson.model';
 import { Group } from './eperson/models/group.model';
+// UMD Customization for LIBDRUM-660
+import { Ldap } from './eperson/models/ldap.model';
+import { LdapDataService } from './eperson/ldap-data.service';
+// End UMD Customization for LIBDRUM-660
 import { JsonPatchOperationsBuilder } from './json-patch/builder/json-patch-operations-builder';
 import { MetadataField } from './metadata/metadata-field.model';
 import { MetadataSchema } from './metadata/metadata-schema.model';
@@ -303,6 +307,9 @@ const PROVIDERS = [
   VocabularyTreeviewService,
   SequenceService,
   GroupDataService,
+  // UMD Customization for LIBDRUM-660
+  LdapDataService,
+  // End UMD Customization for LIBDRUM-660
   FeedbackDataService,
   ResearcherProfileService,
   ProfileClaimService,
@@ -327,6 +334,9 @@ export const models =
     Community,
     EPerson,
     Group,
+    // UMD Customization for LIBDRUM-660
+    Ldap,
+    // End UMD Customizatio for LIBDRUM-660
     ResourcePolicy,
     MetadataSchema,
     MetadataField,

--- a/src/app/core/eperson/ldap-data.service.ts
+++ b/src/app/core/eperson/ldap-data.service.ts
@@ -1,0 +1,45 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { Observable } from 'rxjs';
+import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { FollowLinkConfig } from '../../shared/utils/follow-link-config.model';
+import { dataService } from '../cache/builders/build-decorators';
+import { RemoteDataBuildService } from '../cache/builders/remote-data-build.service';
+import { ObjectCacheService } from '../cache/object-cache.service';
+import { DataService } from '../data/data.service';
+import { DSOChangeAnalyzer } from '../data/dso-change-analyzer.service';
+import { RemoteData } from '../data/remote-data';
+import { RequestService } from '../data/request.service';
+import { HALEndpointService } from '../shared/hal-endpoint.service';
+import { Ldap } from './models/ldap.model';
+import { LDAP } from './models/ldap.resource-type';
+import { NoContent } from '../shared/NoContent.model';
+import { EPerson } from './models/eperson.model';
+
+/**
+ * A service to retrieve {@link Ldap} information from the REST API
+ */
+@Injectable()
+@dataService(LDAP)
+export class LdapDataService extends DataService<Ldap> {
+
+  protected linkPath = 'ldap';
+
+  constructor(
+    protected requestService: RequestService,
+    protected rdbService: RemoteDataBuildService,
+    protected store: Store<any>,
+    protected objectCache: ObjectCacheService,
+    protected halService: HALEndpointService,
+    protected notificationsService: NotificationsService,
+    protected http: HttpClient,
+    protected comparator: DSOChangeAnalyzer<Ldap>
+  ) {
+    super();
+  }
+
+  public getLdap(eperson: EPerson, useCachedVersionIfAvailable = true, reRequestOnStale = true, ...linksToFollow: FollowLinkConfig<Ldap>[]): Observable<RemoteData<Ldap | NoContent>> {
+    return this.findByHref(eperson._links.ldap.href, useCachedVersionIfAvailable, reRequestOnStale, ...linksToFollow);
+  }
+}

--- a/src/app/core/eperson/models/eperson.model.ts
+++ b/src/app/core/eperson/models/eperson.model.ts
@@ -9,6 +9,10 @@ import { HALLink } from '../../shared/hal-link.model';
 import { EPERSON } from './eperson.resource-type';
 import { Group } from './group.model';
 import { GROUP } from './group.resource-type';
+// UMD Customization for LIBDRUM-660
+import { Ldap } from './ldap.model';
+import { LDAP } from './ldap.resource-type';
+// End UMD Customization for LIBDRUM-660
 
 @typedObject
 @inheritSerialization(DSpaceObject)
@@ -73,6 +77,9 @@ export class EPerson extends DSpaceObject {
   _links: {
     self: HALLink;
     groups: HALLink;
+    // UMD Customization for LIBDRUM-660
+    ldap: HALLink;
+    // End UMD Customization for LIBDRUM-660
   };
 
   /**
@@ -82,4 +89,12 @@ export class EPerson extends DSpaceObject {
   @link(GROUP, true)
   public groups?: Observable<RemoteData<PaginatedList<Group>>>;
 
+  // UMD Customization for LIBDRUM-660
+  /**
+   * LDAP information for this EPerson
+   * Will be undefined unless the ldap {@link HALLink} has been resolved.
+   */
+   @link(LDAP, false)
+   public ldap?: Observable<RemoteData<Ldap>>;
+   // End UMD Customization for LIBDRUM-660
 }

--- a/src/app/core/eperson/models/ldap.model.ts
+++ b/src/app/core/eperson/models/ldap.model.ts
@@ -1,0 +1,74 @@
+import { autoserialize, autoserializeAs, deserialize, inheritSerialization } from 'cerialize';
+import { typedObject } from '../../cache/builders/build-decorators';
+
+import { DSpaceObject } from '../../shared/dspace-object.model';
+import { HALLink } from '../../shared/hal-link.model';
+import { LDAP } from './ldap.resource-type';
+import { excludeFromEquals } from '../../utilities/equals.decorators';
+import { Group } from './group.model';
+
+@typedObject
+@inheritSerialization(DSpaceObject)
+export class Ldap extends DSpaceObject {
+  static type = LDAP;
+
+  /**
+   * A string representing the unique name of this Group
+   */
+  @excludeFromEquals
+  @autoserializeAs('name')
+  protected _name: string;
+
+  /**
+   * A string representing the unique handle of this Group
+   */
+  @autoserialize
+  public handle: string;
+
+  /**
+   * A string representing the user's first name
+   */
+  @autoserialize
+  public firstName: string;
+
+  /**
+   * A string representing the user's last name
+   */
+  @autoserialize
+  public lastName: string;
+
+  /**
+   * A string representing the user's phone number
+   */
+   @autoserialize
+   public phone: string;
+
+  /**
+   * The user's email address
+   */
+  @autoserialize
+  public email: string;
+
+  /**
+   * True if the user is faculty, false otherwise
+   */
+   @autoserialize
+   public isFaculty: boolean;
+
+   /**
+   * An array representing the user's UM appointments
+   */
+  @autoserialize
+  public umAppointments: string[];
+
+  /**
+   * The {@link HALLink}s for this Group
+   */
+  @deserialize
+  _links: {
+    self: HALLink;
+  };
+
+  @autoserialize
+  public groups: Group[];
+}

--- a/src/app/core/eperson/models/ldap.resource-type.ts
+++ b/src/app/core/eperson/models/ldap.resource-type.ts
@@ -1,0 +1,10 @@
+import { ResourceType } from '../../shared/resource-type';
+
+/**
+ * The resource type for Ldap
+ *
+ * Needs to be in a separate file to prevent circular
+ * dependencies in webpack.
+ */
+
+export const LDAP = new ResourceType('ldap');

--- a/src/app/shared/testing/ldap-data-service.stub.ts
+++ b/src/app/shared/testing/ldap-data-service.stub.ts
@@ -1,0 +1,23 @@
+import { Observable } from 'rxjs';
+import { RemoteData } from 'src/app/core/data/remote-data';
+import { EPerson } from 'src/app/core/eperson/models/eperson.model';
+import { Ldap } from 'src/app/core/eperson/models/ldap.model';
+import { NoContent } from 'src/app/core/shared/NoContent.model';
+import { createNoContentRemoteDataObject$ } from '../remote-data.utils';
+import { FollowLinkConfig } from '../utils/follow-link-config.model';
+
+/**
+ * Stub for LdapDataService
+ */
+export class LdapDataServiceStub {
+  /**
+   * Always returns no content
+   */
+  public getLdap(
+      eperson: EPerson,
+      useCachedVersionIfAvailable = true,
+      reRequestOnStale = true, ...linksToFollow:
+      FollowLinkConfig<Ldap>[]): Observable<RemoteData<Ldap | NoContent>> {
+    return createNoContentRemoteDataObject$();
+  }
+}

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -315,6 +315,22 @@
 
   "admin.access-control.epeople.form.goToGroups": "Add to groups",
 
+  // UMD Customization for LIBDRUM-660
+  "admin.access-control.epeople.form.ldap.title": "UM Directory Information",
+
+  "admin.access-control.epeople.form.ldap.name": "Name:",
+
+  "admin.access-control.epeople.form.ldap.email": "Email:",
+
+  "admin.access-control.epeople.form.ldap.phone": "Phone:",
+
+  "admin.access-control.epeople.form.ldap.faculty": "Faculty:",
+
+  "admin.access-control.epeople.form.ldap.umAppointment": "UM Appt:",
+
+  "admin.access-control.epeople.form.ldap.groups": "Groups:",
+  // End UMD Customization for LIBDRUM-660
+
   "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
 
   "admin.access-control.epeople.notification.deleted.success": "Successfully deleted EPerson: \"{{name}}\"",


### PR DESCRIPTION
On the EPerson edit form, added a "UM Directory Information" section, with information about the EPerson retrieved from LDAP (if the eperson is known to LDAP).

Added an "ldap" link to the EPerson model, and added an LdapDataService to handle retrieving information from the link.

Added a "stub" LdapDataService to the tests, so that the existing EPerson tests would pass.

https://issues.umd.edu/browse/LIBDRUM-660
