### PR TITLE
LIBDRUM-669. Display matched/unmatched Units based on LDAP criteria

### DIFF
--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.html
@@ -82,7 +82,7 @@
     </div>
   </div>
 
-  <!-- UMD Customization for LIBDRUM-660 --->
+  <!-- UMD Customization for LIBDRUM-660/LIBDRUM-669 --->
   <ng-container *ngVar="(ldap | async) as ldapRD">
     <div *ngIf="ldapRD.hasSucceeded && !ldapRD.hasNoContent">
       <h3>{{ messagePrefix + '.ldap.title' | translate }}</h3>
@@ -107,9 +107,25 @@
             </li>
           </ul>
         </div>
+        <div *ngIf="ldapRD.payload.matchedUnits.length > 0">
+          <li>{{ messagePrefix + '.ldap.matchedUnits' | translate }}</li>
+          <ul>
+            <li *ngFor="let unit of ldapRD.payload.matchedUnits">
+              {{ unit.name }}
+            </li>
+          </ul>
+        </div>
+        <div *ngIf="ldapRD.payload.unmatchedUnits.length > 0">
+          <li>{{ messagePrefix + '.ldap.unmatchedUnits' | translate }}</li>
+          <ul>
+            <li *ngFor="let unmatchedUnit of ldapRD.payload.unmatchedUnits">
+              {{ unmatchedUnit }}
+            </li>
+          </ul>
+        </div>
       </ul>
     </div>
   </ng-container>
-  <!-- End UMD Customization for LIBDRUM-660 -->
+  <!-- End UMD Customization for LIBDRUM-660/LIBDRUM-669 -->
 
 </div>

--- a/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
+++ b/src/app/access-control/epeople-registry/eperson-form/eperson-form.component.spec.ts
@@ -203,7 +203,7 @@ describe('EPersonFormComponent', () => {
         { provide: EPersonDataService, useValue: ePersonDataServiceStub },
         { provide: GroupDataService, useValue: groupsDataService },
         // UMD Customization for LIBDRUM-660
-        { provide: LdapDataService, useValue: LdapDataServiceStub },
+        { provide: LdapDataService, useValue: ldapDataService },
         // End UMD Customization for LIBDRUM-660
         { provide: FormBuilderService, useValue: builderService },
         { provide: NotificationsService, useValue: new NotificationsServiceStub() },

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -67,10 +67,11 @@ import { DspaceRestService } from './dspace-rest/dspace-rest.service';
 import { EPersonDataService } from './eperson/eperson-data.service';
 import { EPerson } from './eperson/models/eperson.model';
 import { Group } from './eperson/models/group.model';
-// UMD Customization for LIBDRUM-660
+// UMD Customization for LIBDRUM-660/LIBDRUM-669
+import { Unit } from './eperson/models/unit.model';
 import { Ldap } from './eperson/models/ldap.model';
 import { LdapDataService } from './eperson/ldap-data.service';
-// End UMD Customization for LIBDRUM-660
+// End UMD Customization for LIBDRUM-660/LIBDRUM-669
 import { JsonPatchOperationsBuilder } from './json-patch/builder/json-patch-operations-builder';
 import { MetadataField } from './metadata/metadata-field.model';
 import { MetadataSchema } from './metadata/metadata-schema.model';
@@ -334,9 +335,10 @@ export const models =
     Community,
     EPerson,
     Group,
-    // UMD Customization for LIBDRUM-660
+    // UMD Customization for LIBDRUM-660/LIBDRUM-669
+    Unit,
     Ldap,
-    // End UMD Customizatio for LIBDRUM-660
+    // End UMD Customizatio for LIBDRUM-660/LIBDRUM-669
     ResourcePolicy,
     MetadataSchema,
     MetadataField,

--- a/src/app/core/eperson/models/ldap.model.ts
+++ b/src/app/core/eperson/models/ldap.model.ts
@@ -6,6 +6,7 @@ import { HALLink } from '../../shared/hal-link.model';
 import { LDAP } from './ldap.resource-type';
 import { excludeFromEquals } from '../../utilities/equals.decorators';
 import { Group } from './group.model';
+import { Unit } from './unit.model';
 
 @typedObject
 @inheritSerialization(DSpaceObject)
@@ -71,4 +72,10 @@ export class Ldap extends DSpaceObject {
 
   @autoserialize
   public groups: Group[];
+
+  @autoserialize
+  public matchedUnits: Unit[];
+
+  @autoserialize
+  public unmatchedUnits: string[];
 }

--- a/src/app/core/eperson/models/unit.model.ts
+++ b/src/app/core/eperson/models/unit.model.ts
@@ -1,0 +1,38 @@
+import { DSpaceObject } from '../../shared/dspace-object.model';
+import {autoserialize, autoserializeAs, deserialize, inheritSerialization} from 'cerialize';
+import { link, typedObject } from '../../cache/builders/build-decorators';
+import { HALLink } from 'src/app/core/shared/hal-link.model';
+import { GROUP } from 'src/app/core/eperson/models/group.resource-type';
+import { Observable } from 'rxjs';
+import { RemoteData } from 'src/app/core/data/remote-data';
+import { PaginatedList } from 'src/app/core/data/paginated-list.model';
+import { Group } from 'src/app/core/eperson/models/group.model';
+import { UNIT } from './unit.resource-type';
+
+@typedObject
+@inheritSerialization(DSpaceObject)
+export class Unit extends DSpaceObject {
+  static type = UNIT;
+
+  @autoserialize
+  facultyOnly: boolean;
+
+  @autoserialize
+  handle: string;
+
+  /**
+   * The {@link HALLink}s for this Unit
+   */
+  @deserialize
+  _links: {
+    self: HALLink;
+    groups: HALLink;
+  };
+
+  /**
+   * The list of Groups this Group is part of
+   * Will be undefined unless the groups {@link HALLink} has been resolved.
+   */
+  @link(GROUP, true)
+  public subgroups?: Observable<RemoteData<PaginatedList<Group>>>;
+}

--- a/src/app/core/eperson/models/unit.resource-type.ts
+++ b/src/app/core/eperson/models/unit.resource-type.ts
@@ -1,0 +1,3 @@
+import { ResourceType } from 'src/app/core/shared/resource-type';
+
+export const UNIT = new ResourceType('unit');

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -315,7 +315,7 @@
 
   "admin.access-control.epeople.form.goToGroups": "Add to groups",
 
-  // UMD Customization for LIBDRUM-660
+  // UMD Customization for LIBDRUM-660/LIBDRUM-669
   "admin.access-control.epeople.form.ldap.title": "UM Directory Information",
 
   "admin.access-control.epeople.form.ldap.name": "Name:",
@@ -329,7 +329,11 @@
   "admin.access-control.epeople.form.ldap.umAppointment": "UM Appt:",
 
   "admin.access-control.epeople.form.ldap.groups": "Groups:",
-  // End UMD Customization for LIBDRUM-660
+
+  "admin.access-control.epeople.form.ldap.matchedUnits": "Units:",
+
+  "admin.access-control.epeople.form.ldap.unmatchedUnits": "Unmatched Units:",
+  // End UMD Customization for LIBDRUM-660/LIBDRUM-669
 
   "admin.access-control.epeople.notification.deleted.failure": "Failed to delete EPerson: \"{{name}}\"",
 


### PR DESCRIPTION
Building on the work done in LIBDRUM-660, modified the "UM Directory Information" section of "Edit EPerson" to display "matched" and "unmatched" Units an EPerson belongs to, based on their LDAP criteria.

The following classes anticipate the "unit" front-end work being done in LIBDRUM-676:

* src/app/core/eperson/unit-data.service.ts
* src/app/core/eperson/models/unit.model.ts
* src/app/core/eperson/models/unit.resource-type.ts

https://issues.umd.edu/browse/LIBDRUM-669

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
