### PR TITLE
LIBDRUM-702. Home page customization.

### DIFF
--- a/src/themes/drum/app/community-list-page/community-list-page.component.html
+++ b/src/themes/drum/app/community-list-page/community-list-page.component.html
@@ -1,6 +1,6 @@
 <div class="container">
   <h2>{{ 'communityList.title' | translate }}</h2>
-  <h3 [attr.alt]="'community.group.faculty.title' | translate">{{ 'community.group.faculty.title' | translate }}</h3>
+  <h3>{{ 'community.group.faculty.title' | translate }}</h3>
   <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP">
   </ds-cg-community-list>
   <h3>{{ 'community.group.um.title' | translate }}</h3>

--- a/src/themes/drum/app/community-list-page/community-list-page.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list-page.component.ts
@@ -1,12 +1,15 @@
 import { Component } from '@angular/core';
 import { CommunityListPageComponent as BaseComponent } from '../../../../app/community-list-page/community-list-page.component';
 
+export const FACULTY_COMMUNITY_GROUP = 0;
+export const UM_COMMUNITY_GROUP = 2;
+
 @Component({
   selector: 'ds-community-list-page',
   templateUrl: './community-list-page.component.html',
 })
 export class CommunityListPageComponent extends BaseComponent {
 
-  public FACULTY_COMMUNITY_GROUP = 0;
-  public UM_COMMUNITY_GROUP = 2;
+  public FACULTY_COMMUNITY_GROUP = FACULTY_COMMUNITY_GROUP;
+  public UM_COMMUNITY_GROUP = UM_COMMUNITY_GROUP;
 }

--- a/src/themes/drum/app/community-list-page/community-list-service.ts
+++ b/src/themes/drum/app/community-list-page/community-list-service.ts
@@ -2,7 +2,7 @@
 import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 
-import { combineLatest as observableCombineLatest, Observable, of as observableOf } from 'rxjs';
+import { combineLatest as observableCombineLatest, Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 
 import { Community } from '../../../../app/core/shared/community.model';
@@ -17,10 +17,6 @@ import { FindListOptions } from '../../../../app/core/data/find-list-options.mod
 
 import { CommunityListService as BaseService } from '../../../../app/community-list-page/community-list-service';
 import { CommunityGroupDataService } from '../core/data/community-group-data.service';
-import { Collection } from 'src/app/core/shared/collection.model';
-import { getCommunityPageRoute } from 'src/app/community-page/community-page-routing-paths';
-import { getCollectionPageRoute } from 'src/app/collection-page/collection-page-routing-paths';
-import { ShowMoreFlatNode } from 'src/app/community-list-page/show-more-flat-node.model';
 
 export const MAX_COMCOLS_PER_PAGE = 20;
 
@@ -80,7 +76,7 @@ export class CommunityListService extends BaseService {
     return this.communityGroupDataService.getTopCommunitiesByGroup(communityGroupId,
       {
         currentPage: options.currentPage,
-        elementsPerPage: MAX_COMCOLS_PER_PAGE,
+        elementsPerPage: options.elementsPerPage,
         sort: {
           field: options.sort.field,
           direction: options.sort.direction

--- a/src/themes/drum/app/community-list-page/community-list-service.ts
+++ b/src/themes/drum/app/community-list-page/community-list-service.ts
@@ -18,7 +18,7 @@ import { FindListOptions } from '../../../../app/core/data/find-list-options.mod
 import { CommunityListService as BaseService } from '../../../../app/community-list-page/community-list-service';
 import { CommunityGroupDataService } from '../core/data/community-group-data.service';
 
-export const MAX_COMCOLS_PER_PAGE = 20;
+export const MAX_COMCOLS_PER_PAGE = 40;
 
 /**
  * The UMD version uses the custom CommunityGroupDataService to get top comunities of a group.

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.html
@@ -8,7 +8,8 @@
         <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
       </button>
       <div class="align-middle pt-2">
-        <a *ngIf="node!==loadingNode" (click)="getNextPage(node)" class="btn btn-outline-primary btn-sm" role="button">
+        <a *ngIf="node!==loadingNode" (click)="getMaxAllowedCommunities(node)" class="btn btn-outline-primary btn-sm"
+          role="button">
           <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
         </a>
         <ds-loading *ngIf="node===loadingNode && dataSource.loading$ | async" class="ds-loading"></ds-loading>

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.html
@@ -1,0 +1,82 @@
+<ds-loading *ngIf="(dataSource.loading$ | async) && !loadingNode" class="ds-loading"></ds-loading>
+<cdk-tree [dataSource]="dataSource" [treeControl]="treeControl">
+  <!-- This is the tree node template for show more node -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: isShowMore" cdkTreeNodePadding
+    class="example-tree-node show-more-node">
+    <div class="btn-group">
+      <button type="button" class="btn btn-default" cdkTreeNodeToggle>
+        <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
+      </button>
+      <div class="align-middle pt-2">
+        <a *ngIf="node!==loadingNode" (click)="getNextPage(node)" class="btn btn-outline-primary btn-sm" role="button">
+          <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
+        </a>
+        <ds-loading *ngIf="node===loadingNode && dataSource.loading$ | async" class="ds-loading"></ds-loading>
+      </div>
+    </div>
+    <div class="text-muted" cdkTreeNodePadding>
+      <div class="d-flex">
+      </div>
+    </div>
+  </cdk-tree-node>
+  <!-- This is the tree node template for expandable nodes (coms and subcoms with children) -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: hasChild" cdkTreeNodePadding
+    class="example-tree-node expandable-node">
+    <div class="btn-group">
+      <button type="button" class="btn btn-default" cdkTreeNodeToggle [title]="'toggle ' + node.name"
+        [attr.aria-label]="'toggle ' + node.name" (click)="toggleExpanded(node)"
+        [ngClass]="(hasChild(null, node)| async) ? 'visible' : 'invisible'">
+        <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}" aria-hidden="true"></span>
+      </button>
+      <h5 class="align-middle pt-2">
+        <a [routerLink]="node.route" class="lead">
+          {{node.name}}
+        </a>
+      </h5>
+    </div>
+    <ds-truncatable [id]="node.id">
+      <div class="text-muted" cdkTreeNodePadding>
+        <div class="d-flex" *ngIf="node.payload.shortDescription">
+          <button type="button" class="btn btn-default invisible">
+            <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}" aria-hidden="true"></span>
+          </button>
+          <ds-truncatable-part [id]="node.id" [minLines]="3">
+            <span>{{node.payload.shortDescription}}</span>
+          </ds-truncatable-part>
+        </div>
+      </div>
+    </ds-truncatable>
+    <div class="d-flex" *ngIf="node===loadingNode && dataSource.loading$ | async" cdkTreeNodePadding>
+      <button type="button" class="btn btn-default invisible">
+        <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}" aria-hidden="true"></span>
+      </button>
+      <ds-loading class="ds-loading"></ds-loading>
+    </div>
+  </cdk-tree-node>
+  <!-- This is the tree node template for leaf nodes (collections and (sub)coms without children) -->
+  <cdk-tree-node *cdkTreeNodeDef="let node; when: !(hasChild && isShowMore)" cdkTreeNodePadding
+    class="example-tree-node childless-node">
+    <div class="btn-group">
+      <button type="button" class="btn btn-default" cdkTreeNodeToggle>
+        <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
+      </button>
+      <h6 class="align-middle pt-2">
+        <a [routerLink]="node.route" class="lead">
+          {{node.name}}
+        </a>
+      </h6>
+    </div>
+    <ds-truncatable [id]="node.id">
+      <div class="text-muted" cdkTreeNodePadding>
+        <div class="d-flex" *ngIf="node.payload.shortDescription">
+          <button type="button" class="btn btn-default invisible">
+            <span class="{{node.isExpanded ? 'fa fa-chevron-down' : 'fa fa-chevron-right'}}" aria-hidden="true"></span>
+          </button>
+          <ds-truncatable-part [id]="node.id" [minLines]="3">
+            <span>{{node.payload.shortDescription}}</span>
+          </ds-truncatable-part>
+        </div>
+      </div>
+    </ds-truncatable>
+  </cdk-tree-node>
+</cdk-tree>

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.spec.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.spec.ts
@@ -129,7 +129,7 @@ describe('CommunityListComponent', () => {
         let showMoreTopComNode = false;
         flatnodes = [...mockTopFlatnodesUnexpanded];
         const currentPage = options.currentPage;
-        const elementsPerPage = this.pageSize;
+        const elementsPerPage = options.elementsPerPage;
         let endPageIndex = (currentPage * elementsPerPage);
         if (endPageIndex >= flatnodes.length) {
           endPageIndex = flatnodes.length;
@@ -220,6 +220,8 @@ describe('CommunityListComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CommunityListComponent);
     component = fixture.componentInstance;
+    component.size = 2;
+    component.ngOnInit();
     fixture.detectChanges();
   });
 

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -125,4 +125,22 @@ export class CommunityListComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+  * The method helps show the entire community list (i.e, upto the MAX_COMCOLS_PER_PAGE) instead
+  * of just getting the next page. This is achived by leaving the current page to the initial
+  * value '1' and changing the elementsPerPage to the MAX_COMCOLS_PER_PAGE. The community list
+  * service gets all the pages (from cache when available) up to the current page, therefore
+  * we do not need to worry about deduplicating list. See https://github.com/umd-lib/dspace-angular/blob/b5a2c0ff39c530983a8caf29709a4c24095a774c/src/themes/drum/app/community-list-page/community-list-service.ts#L55-L58
+  * 
+  * This method is only used by the "show more" button, i.e for top-level communities only, so we
+  * do not need to handle subCommunities or collections.
+  *
+  * 
+  */
+  getMaxAllowedCommunities(node: FlatNode): void {
+    this.loadingNode = node;
+    this.paginationConfig.elementsPerPage = MAX_COMCOLS_PER_PAGE;
+    this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes, this.communityGroupId);
+  }
+
 }

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -31,10 +31,10 @@ import { CommunityDataService } from '../../../../../app/core/data/community-dat
 export class CommunityListComponent implements OnInit, OnDestroy {
 
   // The community group ID to retrieve the top level communities
-  @Input() communityGroupId: number = 0;
+  @Input() communityGroupId = 0;
 
   // Size of the top level communities list displayed on initial rendering
-  @Input() size: number = MAX_COMCOLS_PER_PAGE;
+  @Input() size = MAX_COMCOLS_PER_PAGE;
 
   private expandedNodes: FlatNode[] = [];
   public loadingNode: FlatNode;

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -6,7 +6,7 @@ import { SortDirection, SortOptions } from '../../../../../app/core/cache/models
 import { FindListOptions } from '../../../../../app/core/data/find-list-options.model';
 import { isEmpty } from '../../../../../app/shared/empty.util';
 import { CommunityListDatasource } from '../community-list-datasource';
-import { CommunityListService } from '../community-list-service';
+import { CommunityListService, MAX_COMCOLS_PER_PAGE } from '../community-list-service';
 import { CommunityGroupDataService } from '../../core/data/community-group-data.service';
 import { CommunityDataService } from '../../../../../app/core/data/community-data.service';
 
@@ -30,7 +30,11 @@ import { CommunityDataService } from '../../../../../app/core/data/community-dat
 })
 export class CommunityListComponent implements OnInit, OnDestroy {
 
-  @Input() communityGroupId = 0;
+  // The community group ID to retrieve the top level communities
+  @Input() communityGroupId: number = 0;
+
+  // Size of the top level communities list displayed on initial rendering
+  @Input() size: number = MAX_COMCOLS_PER_PAGE;
 
   private expandedNodes: FlatNode[] = [];
   public loadingNode: FlatNode;
@@ -45,12 +49,12 @@ export class CommunityListComponent implements OnInit, OnDestroy {
 
   constructor(private communityListService: CommunityListService) {
     this.paginationConfig = new FindListOptions();
-    this.paginationConfig.elementsPerPage = 2;
     this.paginationConfig.currentPage = 1;
     this.paginationConfig.sort = new SortOptions('dc.title', SortDirection.ASC);
   }
 
   ngOnInit() {
+    this.paginationConfig.elementsPerPage = this.size;
     this.dataSource = new CommunityListDatasource(this.communityListService);
     this.communityListService.getLoadingNodeFromStore().pipe(take(1)).subscribe((result) => {
       this.loadingNode = result;

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -25,7 +25,7 @@ import { CommunityDataService } from '../../../../../app/core/data/community-dat
 // matching that selector.
 @Component({
   selector: 'ds-cg-community-list',
-  templateUrl: '../../../../../app/community-list-page/community-list/community-list.component.html',
+  templateUrl: './community-list.component.html',
   providers: [CommunityListService, CommunityDataService, CommunityGroupDataService]
 })
 export class CommunityListComponent implements OnInit, OnDestroy {

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -131,11 +131,10 @@ export class CommunityListComponent implements OnInit, OnDestroy {
   * value '1' and changing the elementsPerPage to the MAX_COMCOLS_PER_PAGE. The community list
   * service gets all the pages (from cache when available) up to the current page, therefore
   * we do not need to worry about deduplicating list. See https://github.com/umd-lib/dspace-angular/blob/b5a2c0ff39c530983a8caf29709a4c24095a774c/src/themes/drum/app/community-list-page/community-list-service.ts#L55-L58
-  * 
+  *
   * This method is only used by the "show more" button, i.e for top-level communities only, so we
   * do not need to handle subCommunities or collections.
   *
-  * 
   */
   getMaxAllowedCommunities(node: FlatNode): void {
     this.loadingNode = node;

--- a/src/themes/drum/app/home-page/home-page.component.html
+++ b/src/themes/drum/app/home-page/home-page.component.html
@@ -1,0 +1,15 @@
+<ds-themed-home-news></ds-themed-home-news>
+<div class="container">
+  <ng-container *ngIf="(site$ | async) as site">
+    <ds-view-tracker [object]="site"></ds-view-tracker>
+  </ng-container>
+  <ds-search-form [inPlaceSearch]="false" [searchPlaceholder]="'home.search-form.placeholder' | translate">
+  </ds-search-form>
+  <h2>{{ 'communityList.title' | translate }}</h2>
+  <h3>{{ 'community.group.faculty.title' | translate }}</h3>
+  <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP">
+  </ds-cg-community-list>
+  <h3>{{ 'community.group.um.title' | translate }}</h3>
+  <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP">
+  </ds-cg-community-list>
+</div>

--- a/src/themes/drum/app/home-page/home-page.component.html
+++ b/src/themes/drum/app/home-page/home-page.component.html
@@ -7,9 +7,9 @@
   </ds-search-form>
   <h2>{{ 'communityList.title' | translate }}</h2>
   <h3>{{ 'community.group.faculty.title' | translate }}</h3>
-  <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP">
+  <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
   </ds-cg-community-list>
   <h3>{{ 'community.group.um.title' | translate }}</h3>
-  <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP">
+  <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
   </ds-cg-community-list>
 </div>

--- a/src/themes/drum/app/home-page/home-page.component.ts
+++ b/src/themes/drum/app/home-page/home-page.component.ts
@@ -10,7 +10,7 @@ import { FACULTY_COMMUNITY_GROUP, UM_COMMUNITY_GROUP } from '../community-list-p
   templateUrl: './home-page.component.html'
 })
 export class HomePageComponent extends BaseComponent {
-  public FACULTY_COMMUNITY_GROUP: number = FACULTY_COMMUNITY_GROUP;
-  public UM_COMMUNITY_GROUP: number = UM_COMMUNITY_GROUP;
-  public COMMUNITY_LIST_SIZE: number = 5;
+  public FACULTY_COMMUNITY_GROUP = FACULTY_COMMUNITY_GROUP;
+  public UM_COMMUNITY_GROUP = UM_COMMUNITY_GROUP;
+  public COMMUNITY_LIST_SIZE = 5;
 }

--- a/src/themes/drum/app/home-page/home-page.component.ts
+++ b/src/themes/drum/app/home-page/home-page.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { HomePageComponent as BaseComponent } from '../../../../app/home-page/home-page.component';
+import { FACULTY_COMMUNITY_GROUP, UM_COMMUNITY_GROUP } from '../community-list-page/community-list-page.component';
+
+
+@Component({
+  selector: 'ds-home-page',
+  // styleUrls: ['./home-page.component.scss'],
+  styleUrls: ['../../../../app/home-page/home-page.component.scss'],
+  templateUrl: './home-page.component.html'
+})
+export class HomePageComponent extends BaseComponent {
+  public FACULTY_COMMUNITY_GROUP: number = FACULTY_COMMUNITY_GROUP;
+  public UM_COMMUNITY_GROUP: number = UM_COMMUNITY_GROUP;
+}

--- a/src/themes/drum/app/home-page/home-page.component.ts
+++ b/src/themes/drum/app/home-page/home-page.component.ts
@@ -12,4 +12,5 @@ import { FACULTY_COMMUNITY_GROUP, UM_COMMUNITY_GROUP } from '../community-list-p
 export class HomePageComponent extends BaseComponent {
   public FACULTY_COMMUNITY_GROUP: number = FACULTY_COMMUNITY_GROUP;
   public UM_COMMUNITY_GROUP: number = UM_COMMUNITY_GROUP;
+  public COMMUNITY_LIST_SIZE: number = 5;
 }

--- a/src/themes/drum/eager-theme.module.ts
+++ b/src/themes/drum/eager-theme.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
 import { SharedModule } from '../../app/shared/shared.module';
 import { NavbarComponent } from './app/navbar/navbar.component';
 import { HeaderComponent } from './app/header/header.component';
@@ -13,6 +14,12 @@ import { UmdHeaderComponent } from './app/umd-header/umd-header.component';
 import { FileSectionComponent } from './app/item-page/simple/field-components/file-section/file-section.component';
 import { BitstreamDownloadCounterComponent } from './app/bitstream-download-counter/bitstream-download-counter.component';
 import { CommunityGroup } from './app/core/shared/community-group.model';
+import { HomePageComponent } from './app/home-page/home-page.component';
+import { StatisticsModule } from 'src/app/statistics/statistics.module';
+import { CommunityListPageModule } from 'src/app/community-list-page/community-list-page.module';
+import { CommunityListComponent } from './app/community-list-page/community-list/community-list.component';
+import { CommunityListPageComponent } from './app/community-list-page/community-list-page.component';
+import { HomePageModule } from 'src/app/home-page/home-page.module';
 
 /**
  * Declaration needed to make sure all decorator functions are called in time
@@ -39,6 +46,9 @@ const DECLARATIONS = [
   NavbarComponent,
   UmdEnvironmentBannerComponent,
   UmdHeaderComponent,
+  CommunityListPageComponent,
+  CommunityListComponent,
+  HomePageComponent
 ];
 
 @NgModule({
@@ -47,6 +57,10 @@ const DECLARATIONS = [
     NavbarModule,
     SharedModule,
     ItemPageModule,
+    TranslateModule,
+    StatisticsModule.forRoot(),
+    CommunityListPageModule,
+    HomePageModule,
   ],
   declarations: DECLARATIONS,
   providers: [

--- a/src/themes/drum/lazy-theme.module.ts
+++ b/src/themes/drum/lazy-theme.module.ts
@@ -37,12 +37,10 @@ import { SharedModule } from '../../app/shared/shared.module';
 import { StatisticsModule } from '../../app/statistics/statistics.module';
 import { StoreModule } from '@ngrx/store';
 import { StoreRouterConnectingModule } from '@ngrx/router-store';
-import { TranslateModule } from '@ngx-translate/core';
 import { HomePageModule } from '../../app/home-page/home-page.module';
 import { AppModule } from '../../app/app.module';
 import { ItemPageModule } from '../../app/item-page/item-page.module';
 import { RouterModule } from '@angular/router';
-import { CommunityListPageModule } from '../../app/community-list-page/community-list-page.module';
 import { InfoModule } from '../../app/info/info.module';
 import { StatisticsPageModule } from '../../app/statistics-page/statistics-page.module';
 import { CommunityPageModule } from '../../app/community-page/community-page.module';
@@ -61,8 +59,6 @@ import { PrivacyComponent } from './app/info/privacy/privacy.component';
 
 const DECLARATIONS = [
   PrivacyComponent,
-  CommunityListPageComponent,
-  CommunityListComponent,
 ];
 
 @NgModule({
@@ -78,7 +74,6 @@ const DECLARATIONS = [
     CollectionPageModule,
     CommonModule,
     CommunityFormModule,
-    CommunityListPageModule,
     CommunityPageModule,
     CoreModule,
     DragDropModule,
@@ -105,7 +100,6 @@ const DECLARATIONS = [
     StatisticsPageModule,
     StoreModule,
     StoreRouterConnectingModule,
-    TranslateModule,
     SubmissionModule,
     MyDSpacePageModule,
     MyDspaceSearchModule,


### PR DESCRIPTION
- Display community lists grouped by community groups on the home page.
- Configure the community lists to display only 5 items initially.
- Prevent reload of the home page when the "show more" button is clicked.

https://issues.umd.edu/browse/LIBDRUM-702