### PR TITLE
LIBDRUM-698. Modified config to suppress End User Agreement

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -21,3 +21,7 @@ themes:
 # LIBDRUM-666 - Add PRESERVATION to default standard bundles list
 bundle:
   standardBundles: [ ORIGINAL, THUMBNAIL, LICENSE, PRESERVATION ]
+
+# Disable End User Agreement
+info:
+  enableEndUserAgreement: false

--- a/src/themes/drum/app/footer/footer.component.html
+++ b/src/themes/drum/app/footer/footer.component.html
@@ -55,10 +55,6 @@
         </li>
         <li>
           <a class="text-white"
-             routerLink="info/end-user-agreement">{{ 'footer.link.end-user-agreement' | translate}}</a>
-        </li>
-        <li>
-          <a class="text-white"
              routerLink="info/feedback">{{ 'footer.link.feedback' | translate}}</a>
         </li>
         <li>


### PR DESCRIPTION
Modified the "config/config.yml" file to suppress display of the "End User Agreement".

Also removed the "End User Agreement" link from the footer.

https://issues.umd.edu/browse/LIBDRUM-698
