### PR TITLE
LIBDRUM-683. Initial implementation of Dataset JSON-LD

### DIFF
--- a/src/themes/drum/app/item-page/json-ld/json-ld-dataset.component.ts
+++ b/src/themes/drum/app/item-page/json-ld/json-ld-dataset.component.ts
@@ -1,0 +1,52 @@
+import { DOCUMENT } from '@angular/common';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
+import { Item } from 'src/app/core/shared/item.model';
+import { JsonLdService } from './json-ld.service';
+import { DatasetJsonLdTransformer } from './json-ld-dataset.transfomer';
+import { DSpaceObject } from 'src/app/core/shared/dspace-object.model';
+
+@Component({
+  selector: 'ds-json-ld-dataset',
+  styles: [],
+  template: ''
+})
+export class JsonLdDatasetComponent implements OnInit, OnDestroy {
+  transformer: DatasetJsonLdTransformer;
+
+  /**
+   * The id to assign to the HTML script tag containing the JSON-LD schema
+   */
+  @Input() scriptId: string;
+
+  /**
+   * The Item to display the JSON-LD for
+   */
+  @Input() item: Item;
+
+  constructor(
+    protected jsonLdService: JsonLdService,
+    @Inject(DOCUMENT) protected document: any,
+  ) {
+    this.transformer = new DatasetJsonLdTransformer();
+  }
+
+  /**
+   * Appends the JSON-LD for the item, if the item is a Dataset.
+   */
+  ngOnInit(): void {
+    if (this.transformer.handles(this.item)) {
+      let url = this.document.location.href;
+      let jsonLd = this.transformer.asJsonLd(url, this.item);
+      this.jsonLdService.insertJsonLdSchema(this.document, this.scriptId, jsonLd);
+    }
+  }
+
+  /**
+   * Removes the JSON-LD added for the item, if any.
+   */
+  ngOnDestroy(): void {
+    this.jsonLdService.removeJsonLdSchema(this.document, this.scriptId);
+  }
+}
+
+

--- a/src/themes/drum/app/item-page/json-ld/json-ld-dataset.transfomer.ts
+++ b/src/themes/drum/app/item-page/json-ld/json-ld-dataset.transfomer.ts
@@ -1,0 +1,67 @@
+import { escape } from 'lodash';
+import { DSpaceObject } from 'src/app/core/shared/dspace-object.model';
+
+export class DatasetJsonLdTransformer {
+  /**
+   * Returns true if the DSpaceObject is a Dataset, false otherwise.
+   *
+   * @param item the DSpaceObject to check
+   * @return true if the DSpaceObject is a Dataset, false otherwise.
+   */
+  handles(item: DSpaceObject): boolean {
+    return item.hasMetadata('dc.type', { value: 'Dataset' } );
+  }
+
+  private fromDspaceObject(url: string, dspaceObject: DSpaceObject): any {
+    // Run each value (or array of values) through escape/escapeAll to prevent
+    // cross-site scripting (XSS) attacks from user-input values.
+    return {
+      'type': escape(dspaceObject.firstMetadataValue('dc.type') || ''),
+      'name': escape(dspaceObject.firstMetadataValue('dc.title') || ''),
+      'url': escape(url),
+      'temporalCoverage': escape(dspaceObject.firstMetadataValue('dc.date.issued')  || ''),
+      'descriptions': this.escapeAll(dspaceObject.allMetadataValues('dc.description.abstract')),
+      'creators': this.escapeAll(dspaceObject.allMetadataValues('dc.contributor.author')),
+      'identifiers': this.escapeAll(dspaceObject.allMetadataValues(['dc.identifier.uri', 'dc.identifier.*', 'dc.identifier'])),
+      'license': escape(dspaceObject.firstMetadataValue('dc.rights.uri')  || '')
+    };
+  }
+
+  asJsonLd(url: string, dspaceObject: DSpaceObject): any {
+    let jsonObj = this.fromDspaceObject(url, dspaceObject);
+    let description = jsonObj.descriptions.join(' ');
+    let identifiers = jsonObj.identifiers;
+    let creator = [];
+
+    for (const creatorName of jsonObj.creators) {
+      let c = {
+        '@type': 'Person',
+        'name': creatorName
+      };
+      creator.push(c);
+    }
+
+    return {
+      '@context' : 'http://schema.org',
+      '@type': jsonObj.type,
+      'name': jsonObj.name,
+      'description': description,
+      'url': jsonObj.url,
+      'temporalCoverage': jsonObj.temporalCoverage,
+      'creator': creator,
+      'identifier': identifiers,
+      'license': jsonObj.license
+    };
+  }
+
+  /**
+   * Runs "escape" on each value in the string array, returning an array of
+   * escaped string.
+   *
+   * @param values the string array of values to escape
+   * @return an array of escaped string values.
+   */
+  private escapeAll(values: string[]): string[] {
+    return values.map(id => escape(id));
+  }
+}

--- a/src/themes/drum/app/item-page/json-ld/json-ld-dataset.transformer.spec.ts
+++ b/src/themes/drum/app/item-page/json-ld/json-ld-dataset.transformer.spec.ts
@@ -1,0 +1,51 @@
+import { cloneDeep } from 'lodash';
+import { DatasetJsonLdTransformer } from './json-ld-dataset.transfomer';
+import { emptyDataset, escapeTestDataset, fullDataset, notADataset } from './mocks/mock-json-ld-items';
+
+describe('DatasetJsonLdTransformer', () => {
+  let transformer: DatasetJsonLdTransformer;
+
+  beforeEach(() => {
+    transformer = new DatasetJsonLdTransformer();
+  });
+
+  describe('handles', () => {
+    it('returns true if the "dc.type" metadata field of the item is "Dataset"', () => {
+      let item = fullDataset.dspaceObject;
+      expect(transformer.handles(item)).toBe(true);
+    });
+
+    describe('returns false', () => {
+      it('if the "dc.type" metadata field of the item is not "Dataset"', () => {
+        let item = notADataset.dspaceObject;
+        expect(transformer.handles(item)).toBe(false);
+      });
+
+      it('if the "dc.type" metadata field of the item is not present', () => {
+        let item = cloneDeep(notADataset.dspaceObject); // Cloning because item is modified by test
+        item.removeMetadata('dc.type');
+        expect(transformer.handles(item)).toBe(false);
+      });
+    });
+  });
+
+  describe('asJson', ()=> {
+    it('fullDataset - returns the JSON-LD object for the given DSpaceObject', () => {
+      let url = fullDataset.url;
+      let jsonLd = transformer.asJsonLd(url, fullDataset.dspaceObject);
+      expect(jsonLd).toEqual(fullDataset.expectedJsonLd);
+    });
+
+    it('emptyDataset - returns a JSON-LD object with default values when values are not given', () => {
+      let url = emptyDataset.url;
+      let jsonLd = transformer.asJsonLd(url, emptyDataset.dspaceObject);
+      expect(jsonLd).toEqual(emptyDataset.expectedJsonLd);
+    });
+
+    it('escapeTestDataset - returns a JSON-LD object with escaped values', () => {
+      let url = escapeTestDataset.url;
+      let jsonLd = transformer.asJsonLd(url, escapeTestDataset.dspaceObject);
+      expect(jsonLd).toEqual(escapeTestDataset.expectedJsonLd);
+    });
+  });
+});

--- a/src/themes/drum/app/item-page/json-ld/json-ld.service.spec.ts
+++ b/src/themes/drum/app/item-page/json-ld/json-ld.service.spec.ts
@@ -1,0 +1,39 @@
+import { DOCUMENT } from '@angular/common';
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { JsonLdService } from './json-ld.service';
+import { emptyDataset, fullDataset } from './mocks/mock-json-ld-items';
+
+describe('JsonLdService', () => {
+  let jsonLdService: JsonLdService;
+  let mockDocument: Document;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+    });
+    mockDocument = TestBed.inject(DOCUMENT).implementation.createHTMLDocument();
+    jsonLdService = new JsonLdService();
+  }));
+
+  describe('insertJsonLdSchema', () => {
+    it('should insert a JSON-LD script into the HTML <head>', () => {
+      jsonLdService.insertJsonLdSchema(mockDocument, 'test-json-ld', fullDataset.expectedJsonLd);
+      expect(mockDocument.getElementById('test-json-ld').innerHTML).not.toBeNull();
+      expect(mockDocument.getElementById('test-json-ld').innerHTML).toEqual(JSON.stringify(fullDataset.expectedJsonLd));
+    });
+  });
+
+  describe('removeJsonLdSchema', () => {
+    it('should remove a JSON-LD script with the given schema id from the HTML <head>', () => {
+      jsonLdService.insertJsonLdSchema(mockDocument, 'test-full-dataset', fullDataset.expectedJsonLd);
+      jsonLdService.insertJsonLdSchema(mockDocument, 'test-empty-dataset', emptyDataset.expectedJsonLd);
+
+      expect(mockDocument.getElementById('test-full-dataset').innerHTML).not.toBeNull();
+      expect(mockDocument.getElementById('test-empty-dataset').innerHTML).not.toBeNull();
+
+      jsonLdService.removeJsonLdSchema(mockDocument, 'test-empty-dataset');
+
+      expect(mockDocument.getElementById('test-empty-dataset')).toBeNull();
+      expect(mockDocument.getElementById('test-full-dataset').innerHTML).toEqual(JSON.stringify(fullDataset.expectedJsonLd));
+    });
+  });
+});

--- a/src/themes/drum/app/item-page/json-ld/json-ld.service.ts
+++ b/src/themes/drum/app/item-page/json-ld/json-ld.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+/**
+ * This service appends and removes JSON-LD scripts in the "head" tag of the
+ * HTML document.
+ *
+ * Typical use is to call "insertJsonLdSchema" in an "ngOnInit" method of a
+ * component, and call "removeJsonLdSchema" in the "ngOnDestroy" method.
+ */
+export class JsonLdService {
+  /**
+   * Appends the given JSON-LD to the given Document's <head> tag, with the
+   * provided scriptId.
+   *
+   * The "scriptId" value should be unique, as it is used to remove the
+   * JSON-LD when the item is no longer displayed.
+   *
+   * WARNING: This implementation uses "JSON.stringify" which could result in
+   * XSS attacks. Ensure that all string values provided in the "jsonLd"
+   * parameter have been properly escaped prior to calling this method.
+   *
+   * @param document the Document to add the JSON-LD script to
+   * @param scriptId the HTML "id" field to identify the JSON-LD script
+   * @param jsonLd the JSON-LD object to insert in the document head.
+   */
+  insertJsonLdSchema(document: Document, scriptId: string, jsonLd: any): void {
+    let script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.text = JSON.stringify(jsonLd);
+    script.id = scriptId;
+    document.head.appendChild(script);
+  }
+
+  /**
+   * Removes the element with the given scriptId from the given Document.
+   *
+   * @param document the Document to remove the element from.
+   * @param scriptId the HTML "id" field of the element to remove.
+   */
+  removeJsonLdSchema(document: Document, scriptId: string): void {
+    let elementToRemove = document.getElementById(scriptId);
+    if (elementToRemove) {
+      document.head.removeChild(elementToRemove);
+    }
+  }
+}

--- a/src/themes/drum/app/item-page/json-ld/mocks/mock-json-ld-items.ts
+++ b/src/themes/drum/app/item-page/json-ld/mocks/mock-json-ld-items.ts
@@ -1,0 +1,432 @@
+import { escape } from 'lodash';
+import { Item } from 'src/app/core/shared/item.model';
+
+/**
+ * A DSpace object that is not a Dataset
+ */
+export const notADataset = {
+  'url': 'https://example.org/items/notADataset',
+  'dspaceObject':
+  Object.assign(new Item(),
+    {
+      'id': 'emptyDataset ID',
+      'uuid': 'emptyDataset UUID',
+      'name': '',
+      'handle': '1903/99999',
+      'metadata': {
+        'dc.type': [
+          {
+            'value': 'Technical Report',
+            'language': 'en_US',
+          }
+        ]
+      },
+    }
+  ),
+  'expectedJsonLd': ''
+};
+
+/**
+ * A Dataset, with missing values for every field
+ */
+export const emptyDataset = {
+  // The URL to use when constructing the JSON-LD object
+  'url': 'https://example.org/items/emptyDataset',
+  // The DSpaceObject to use
+  'dspaceObject':
+    Object.assign(new Item(),
+      {
+        'id': 'emptyDataset ID',
+        'uuid': 'emptyDataset UUID',
+        'name': '',
+        'handle': '1903/99999',
+        'metadata': {
+          'dc.type': [
+            {
+              'value': 'Dataset',
+              'language': 'en_US',
+            }
+          ]
+        },
+      }
+    ),
+  // The expected JSON-LD object
+  'expectedJsonLd':
+    {
+      '@context' : 'http://schema.org',
+      '@type' : 'Dataset',
+      'name':'',
+      'description':'',
+      'url':'https://example.org/items/emptyDataset',
+      'temporalCoverage':'',
+      'creator': [],
+      'identifier': [],
+      'license': ''
+    }
+};
+
+/**
+ * A Dataset for verifying that each field is properly escaped.
+ */
+export const escapeTestDataset = {
+  'url': 'https://example.org/items/escapeTestDataset',
+  'dspaceObject':
+    Object.assign(new Item(),
+    {
+      'id': 'escapeTestDataset ID',
+      'uuid': 'escapeTestDataset UUID',
+      'name': '',
+      'handle': '1903/99998',
+      'metadata': {
+        'dc.contributor.author': [
+          {
+            'value': 'Pound, Marc </script><script>alert("XXS author1")</script>',
+            'language': null,
+          },
+          {
+            'value': 'Wolfire, Mark  </script><script>alert("XXS author2")</script>',
+            'language': null,
+          }
+        ],
+        'dc.date.issued': [
+          {
+            'value': '2022-08-31 </script><script>alert("XXS date")</script>',
+            'language': null,
+          }
+        ],
+        'dc.description': [
+          {
+            'value': 'escapeTestDataset Description </script><script>alert("XXS description")</script>',
+            'language': 'en_US',
+          }
+        ],
+        'dc.description.abstract': [
+          {
+            'value': 'escapeTestDataset Abstract </script><script>alert("XXS abstract")</script>',
+            'language': 'en_US',
+          }
+        ],
+        'dc.identifier': [
+          {
+            'value': 'https://doi.org/10.13016/hohs-ldyr </script><script>alert("XXS identifier")</script>',
+            'language': null,
+          }
+        ],
+        'dc.identifier.uri': [
+          {
+            'value': 'http://hdl.handle.net/1903/29105 </script><script>alert("XXS identifier")</script>',
+            'language': null,
+          }
+        ],
+        'dc.rights.uri': [
+          {
+            'value': 'http://creativecommons.org/publicdomain/zero/1.0/ </script><script>alert("XXS rights")</script>',
+            'language': '*',
+            'authority': null,
+            'confidence': -1,
+            'place': 0
+          }
+        ],
+        'dc.title': [
+          {
+            'value': 'escapeTestDataset Title </script><script>alert("XXS rights")</script>',
+            'language': 'en_US',
+          }
+        ],
+        'dc.type': [
+          {
+            'value': 'Dataset',
+            'language': 'en_US',
+          }
+        ]
+      },
+    }),
+  'expectedJsonLd':
+    {
+      '@context' : 'http://schema.org',
+      '@type' : 'Dataset',
+      'name':'escapeTestDataset Title &lt;/script&gt;&lt;script&gt;alert(&quot;XXS rights&quot;)&lt;/script&gt;',
+      'description': 'escapeTestDataset Abstract &lt;/script&gt;&lt;script&gt;alert(&quot;XXS abstract&quot;)&lt;/script&gt;',
+      'url':'https://example.org/items/escapeTestDataset',
+      'temporalCoverage':'2022-08-31 &lt;/script&gt;&lt;script&gt;alert(&quot;XXS date&quot;)&lt;/script&gt;',
+      'creator': [
+          {
+              '@type': 'Person',
+              'name': 'Pound, Marc &lt;/script&gt;&lt;script&gt;alert(&quot;XXS author1&quot;)&lt;/script&gt;'
+          },
+          {
+              '@type': 'Person',
+              'name': 'Wolfire, Mark  &lt;/script&gt;&lt;script&gt;alert(&quot;XXS author2&quot;)&lt;/script&gt;'
+          }
+      ],
+      'identifier': [
+        'http://hdl.handle.net/1903/29105 &lt;/script&gt;&lt;script&gt;alert(&quot;XXS identifier&quot;)&lt;/script&gt;',
+        'https://doi.org/10.13016/hohs-ldyr &lt;/script&gt;&lt;script&gt;alert(&quot;XXS identifier&quot;)&lt;/script&gt;'
+      ],
+      'license':'http://creativecommons.org/publicdomain/zero/1.0/ &lt;/script&gt;&lt;script&gt;alert(&quot;XXS rights&quot;)&lt;/script&gt;'
+    },
+};
+
+/**
+ * A realistic Dataset from an actual DSpace object.
+ */
+export const fullDataset = {
+  // The URL to use when constructing the JSON-LD object
+  'url': 'https://example.org/items/fullDataset',
+  // The DSpaceObject to use
+  'dspaceObject':
+    Object.assign(new Item(),
+      {
+        'id': 'ff20f203-99ef-4d9c-8c24-81d8aa4886dc',
+        'uuid': 'ff20f203-99ef-4d9c-8c24-81d8aa4886dc',
+        'name': 'Example code listings for the PhotoDissociation Region Toolbox',
+        'handle': '1903/29105',
+        'metadata': {
+          'dc.contributor.author': [
+            {
+              'value': 'Pound, Marc',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            },
+            {
+              'value': 'Wolfire, Mark',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 1
+            }
+          ],
+          'dc.date.accessioned': [
+            {
+              'value': '2022-08-31T19:13:22Z',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.date.available': [
+            {
+              'value': '2022-08-31T19:13:22Z',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.date.issued': [
+            {
+              'value': '2022-08-31',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.description': [
+            {
+              'value': 'We use a Github open-source public repository (https://github.com/mpound/pdrtpy) that includes the Python package code, text documentation files, and the FITS files of the models. Code is checked against the PEP8 coding style\r\nand regression and integration tests are run and at code check-in using Github Actions. For more info, see Pound & Wolfire (2022) and the github repo.',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.description.abstract': [
+            {
+              'value': 'These are example code listings for the PhotoDissociation Region Toolbox (https://dustem.astro.umd.edu), and companion to the manuscript \'The PhotoDissociation Region Toolbox: Software and Models for Astrophysical Analysis\', by Pound & Wolfire (2022).  These code snippets show typical ways to use the Toolbox and reproduce most of the figures in the manuscript.   The code is written in Python 3 and demonstrate the pdrtpy Python package (https://pdrtpy.readthedocs.io).',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.description.sponsorship': [
+            {
+              'value': '1. NASA Astrophysics Data Analysis Program award #80NSSC19K0573\r\n2. SOFIA Legacy Program, FEEDBACK, provided by NASA\r\nthrough award SOF070077 issued by USRA to the University of Maryland\r\n3. JWST-ERS program ID 1288 through a grant from the Space Telescope Science Institute under\r\nNASA contract NAS5-03127 to the University of Maryland.',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.identifier': [
+            {
+              'value': 'https://doi.org/10.13016/hohs-ldyr',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.identifier.uri': [
+            {
+              'value': 'http://hdl.handle.net/1903/29105',
+              'language': null,
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.language.iso': [
+            {
+              'value': 'en_US',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.relation.isAvailableAt': [
+            {
+              'value': 'Astronomy',
+              'language': 'en_us',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            },
+            {
+              'value': 'College of Computer, Mathematical & Natural Sciences',
+              'language': 'en_us',
+              'authority': null,
+              'confidence': -1,
+              'place': 1
+            },
+            {
+              'value': 'Digital Repository at the University of Maryland',
+              'language': 'en_us',
+              'authority': null,
+              'confidence': -1,
+              'place': 2
+            },
+            {
+              'value': 'University of Maryland (College Park, MD)',
+              'language': 'en_us',
+              'authority': null,
+              'confidence': -1,
+              'place': 3
+            }
+          ],
+          'dc.rights': [
+            {
+              'value': 'CC0 1.0 Universal',
+              'language': '*',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.rights.uri': [
+            {
+              'value': 'http://creativecommons.org/publicdomain/zero/1.0/',
+              'language': '*',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.subject': [
+            {
+              'value': 'photodissociation region',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            },
+            {
+              'value': 'Python data analysis',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 1
+            },
+            {
+              'value': 'interstellar gas',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 2
+            }
+          ],
+          'dc.title': [
+            {
+              'value': 'Example code listings for the PhotoDissociation Region Toolbox',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ],
+          'dc.type': [
+            {
+              'value': 'Dataset',
+              'language': 'en_US',
+              'authority': null,
+              'confidence': -1,
+              'place': 0
+            }
+          ]
+        },
+        'inArchive': true,
+        'discoverable': true,
+        'withdrawn': false,
+        'lastModified': '2022-09-01T15:59:14.970+00:00',
+        'entityType': null,
+        'type': 'item',
+        '_links': {
+          'accessStatus': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/accessStatus'
+          },
+          'bundles': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/bundles'
+          },
+          'mappedCollections': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/mappedCollections'
+          },
+          'owningCollection': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/owningCollection'
+          },
+          'relationships': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/relationships'
+          },
+          'version': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/version'
+          },
+          'templateItemOf': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/templateItemOf'
+          },
+          'thumbnail': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc/thumbnail'
+          },
+          'self': {
+            'href': 'http://localhost:8080/server/api/core/items/ff20f203-99ef-4d9c-8c24-81d8aa4886dc'
+          }
+        }
+      }
+    ),
+  'expectedJsonLd':
+    {
+      '@context' : 'http://schema.org',
+      '@type' : 'Dataset',
+      'name':'Example code listings for the PhotoDissociation Region Toolbox',
+      'description': escape('These are example code listings for the PhotoDissociation Region Toolbox (https://dustem.astro.umd.edu), and companion to the manuscript \'The PhotoDissociation Region Toolbox: Software and Models for Astrophysical Analysis\', by Pound & Wolfire (2022).  These code snippets show typical ways to use the Toolbox and reproduce most of the figures in the manuscript.   The code is written in Python 3 and demonstrate the pdrtpy Python package (https://pdrtpy.readthedocs.io).'),
+      'url':'https://example.org/items/fullDataset',
+      'temporalCoverage':'2022-08-31',
+      'creator': [
+          {
+              '@type': 'Person',
+              'name': 'Pound, Marc'
+          },
+          {
+              '@type': 'Person',
+              'name': 'Wolfire, Mark'
+          }
+      ],
+      'identifier': [
+      'http://hdl.handle.net/1903/29105','https://doi.org/10.13016/hohs-ldyr'
+      ],
+      'license': 'http://creativecommons.org/publicdomain/zero/1.0/'
+    }
+};

--- a/src/themes/drum/app/item-page/simple/item-page.component.html
+++ b/src/themes/drum/app/item-page/simple/item-page.component.html
@@ -1,0 +1,14 @@
+<div class="container" *ngVar="(itemRD$ | async) as itemRD">
+  <div class="item-page" *ngIf="itemRD?.hasSucceeded" @fadeInOut>
+    <div *ngIf="itemRD?.payload as item">
+      <ds-json-ld-dataset [item]="item" scriptId='json-ld-dataset'></ds-json-ld-dataset>
+      <ds-item-alerts [item]="item"></ds-item-alerts>
+      <ds-item-versions-notice [item]="item"></ds-item-versions-notice>
+      <ds-view-tracker [object]="item"></ds-view-tracker>
+      <ds-listable-object-component-loader *ngIf="!item.isWithdrawn || (isAdmin$|async)" [object]="item" [viewMode]="viewMode"></ds-listable-object-component-loader>
+      <ds-item-versions class="mt-2" [item]="item" [displayActions]="false"></ds-item-versions>
+    </div>
+  </div>
+  <ds-error *ngIf="itemRD?.hasFailed" message="{{'error.item' | translate}}"></ds-error>
+  <ds-themed-loading *ngIf="itemRD?.isLoading" message="{{'loading.item' | translate}}"></ds-themed-loading>
+</div>

--- a/src/themes/drum/app/item-page/simple/item-page.component.ts
+++ b/src/themes/drum/app/item-page/simple/item-page.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { AuthService } from 'src/app/core/auth/auth.service';
+import { AuthorizationDataService } from 'src/app/core/data/feature-authorization/authorization-data.service';
+import { ItemDataService } from 'src/app/core/data/item-data.service';
+import { ItemPageComponent as BaseComponent } from '../../../../../app/item-page/simple/item-page.component';
+import { fadeInOut } from '../../../../../app/shared/animations/fade';
+
+/**
+ * This component renders a simple item page.
+ * The route parameter 'id' is used to request the item it represents.
+ * All fields of the item that should be displayed, are defined in its template.
+ */
+@Component({
+  selector: 'ds-item-page',
+  styleUrls: ['../../../../../app/item-page/simple/item-page.component.scss'],
+  templateUrl: 'item-page.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [fadeInOut]
+})
+export class ItemPageComponent extends BaseComponent {
+  constructor(
+    protected route: ActivatedRoute,
+    router: Router,
+    items: ItemDataService,
+    authService: AuthService,
+    authorizationService: AuthorizationDataService
+  ) {
+    super(route, router, items, authService, authorizationService);
+  }
+}

--- a/src/themes/drum/lazy-theme.module.ts
+++ b/src/themes/drum/lazy-theme.module.ts
@@ -56,8 +56,12 @@ import { RootModule } from '../../app/root.module';
 import { PrivacyComponent } from './app/info/privacy/privacy.component';
 import { UnitsRegistryComponent } from 'src/app/access-control/unit-registry/units-registry.component';
 import { EmbargoListPageModule } from '../../app/embargo-list/embargo-list-page.module';
+import { ItemPageComponent } from './app/item-page/simple/item-page.component';
+import { JsonLdDatasetComponent } from './app/item-page/json-ld/json-ld-dataset.component';
 
 const DECLARATIONS = [
+  ItemPageComponent,
+  JsonLdDatasetComponent,
   PrivacyComponent,
   UnitsRegistryComponent,
 ];


### PR DESCRIPTION
Created a "JsonLdService" provides JSON-LD scripts for insertion into web pages, based on the items "dc.type". This implementation currently works for items of type "Dataset".

https://issues.umd.edu/browse/LIBDRUM-683
