### PR TITLE
LIBDRUM-727. Added explanatory note to Creative Commons license step

### DIFF
--- a/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
+++ b/src/app/submission/sections/cc-license/submission-section-cc-licenses.component.html
@@ -1,3 +1,26 @@
+<div>
+  You may add a Creative Commons License to your item. These licenses help
+  inform others how the item may or may not be used. View the
+  <a href="https://creativecommons.org/faq/" target="_blank">Creative Commons FAQ</a>
+  for more information about licensing options.
+  <br>
+  <br>
+  <ul>
+    <li>
+      <a href="https://creativecommons.org/about/cc0/" target="_blank">CC0</a> – choose this option
+      to waive all copyrights to the item (this is equivalent to placing the item into the public domain).
+    </li>
+    <li>
+      Creative Commons – choose this option to further specify if commercial
+      uses or modifications of this item are allowed.
+      (<a href="https://en.wikipedia.org/wiki/Share-alike" target="_blank">Learn more about the
+        Creative Commons“ShareAlike” model.</a>)
+    </li>
+    <li>
+      No Creative Commons License – You may skip this step if you do not wish to specify a Creative Commons license.
+    </li>
+  </ul>
+</div>
 <div class="mb-4 ccLicense-select">
   <ds-select
     [disabled]="!submissionCcLicenses">

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5128,5 +5128,6 @@
 
   "embargo-list.table.label.endDate": "End Date",
 
+  "submission.sections.submit.progressbar.equitableAccessSubmission": "Equitable Access",
   // End UMD Customization
 }


### PR DESCRIPTION
Added an explanatory note to Creative Commons license step. Editing the
"stock" file, because this component is not in the "src/themes/custom/"
hierarchy, indicating that it is not themeable).

https://umd-dit.atlassian.net/browse/LIBDRUM-727