### PR TITLE
LIBDRUM-678. Added Embargo/Restricted Access handling

### DIFF
--- a/src/app/app-routing-paths.ts
+++ b/src/app/app-routing-paths.ts
@@ -130,5 +130,6 @@ export const HEALTH_PAGE_PATH = 'health';
 // UMD Customization
 export const EMBARGO_LIST_PAGE_PATH = 'embargo-list';
 export const ETDUNIT_PATH = 'etdunits';
+export const RESTRICTED_ACCESS_MODULE_PATH = 'restricted-access';
 // End UMD Customization
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -24,6 +24,7 @@ import {
   // UMD Customization
   EMBARGO_LIST_PAGE_PATH,
   ETDUNIT_PATH,
+  RESTRICTED_ACCESS_MODULE_PATH,
   // End UMD Customization
 } from './app-routing-paths';
 import { COLLECTION_MODULE_PATH } from './collection-page/collection-page-routing-paths';
@@ -244,6 +245,12 @@ import { ThemedPageErrorComponent } from './page-error/themed-page-error.compone
             path: ETDUNIT_PATH,
             loadChildren: () => import('./etdunit-registry/etdunits.module').then((m) => m.EtdUnitsModule),
             canActivate: [SiteAdministratorGuard],
+          },
+          {
+            path: RESTRICTED_ACCESS_MODULE_PATH,
+            loadChildren: () => import('./restricted-access/restricted-access-page.module')
+              .then((m) => m.RestrictedAccessPageModule),
+            canActivate: [EndUserAgreementCurrentUserGuard]
           },
           // End UMD Customization
           { path: '**', pathMatch: 'full', component: ThemedPageNotFoundComponent },

--- a/src/app/core/shared/bitstream.model.ts
+++ b/src/app/core/shared/bitstream.model.ts
@@ -67,7 +67,28 @@ export class Bitstream extends DSpaceObject implements ChildHALResource {
   @link(BUNDLE)
   bundle?: Observable<RemoteData<Bundle>>;
 
+  // UMD Customization
+  /**
+   * A String indicating whether (and how long) this object has restricted
+   * access due to an embargo:
+   *
+   * - A date string (in "yyyy-MM-DD" format) - The lift date of the embargo
+   * - "FOREVER" - the embargo restriction is forever
+   * - "NONE" - there is no embargo restriction
+   */
+  @autoserialize
+  embargoRestriction: string;
+  // End UMD Customization
+
   getParentLinkKey(): keyof this['_links'] {
     return 'format';
+  }
+
+  /**
+   * Returns true if this bitstream has active embargo restrictions,
+   * false otherwise.
+   */
+  isEmbargoed() {
+    return 'NONE' !== this.embargoRestriction;
   }
 }

--- a/src/app/restricted-access/restricted-access-page-routing.module.ts
+++ b/src/app/restricted-access/restricted-access-page-routing.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { RestrictedAccessComponent } from './restricted-access.component';
+
+/**
+ * Routing module to help navigate Bitstream pages
+ */
+@NgModule({
+  imports: [
+    RouterModule.forChild([
+      {
+        path: '',
+        component: RestrictedAccessComponent,
+        data: { title: 'bitstream.restricted-access.title' },
+      }
+    ])
+  ],
+})
+
+export class RestrictedAccessPageRoutingModule {
+}

--- a/src/app/restricted-access/restricted-access-page-routing.module.ts
+++ b/src/app/restricted-access/restricted-access-page-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { BitstreamPageResolver } from '../bitstream-page/bitstream-page.resolver';
 import { RestrictedAccessComponent } from './restricted-access.component';
 
 /**
@@ -12,9 +13,20 @@ import { RestrictedAccessComponent } from './restricted-access.component';
         path: '',
         component: RestrictedAccessComponent,
         data: { title: 'bitstream.restricted-access.title' },
+      },
+      {
+        path: ':id',
+        component: RestrictedAccessComponent,
+        data: { title: 'bitstream.restricted-access.title' },
+        resolve: {
+          bitstream: BitstreamPageResolver
+        },
       }
     ])
   ],
+  providers: [
+    BitstreamPageResolver,
+  ]
 })
 
 export class RestrictedAccessPageRoutingModule {

--- a/src/app/restricted-access/restricted-access-page.module.ts
+++ b/src/app/restricted-access/restricted-access-page.module.ts
@@ -1,0 +1,23 @@
+import { DatePipe } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { SharedModule } from '../shared/shared.module';
+import { RestrictedAccessPageRoutingModule } from './restricted-access-page-routing.module';
+import { RestrictedAccessComponent } from './restricted-access.component';
+
+@NgModule({
+  imports: [
+    RestrictedAccessPageRoutingModule,
+    SharedModule,
+    TranslateModule
+  ],
+  declarations: [
+    RestrictedAccessComponent,
+  ],
+  providers: [
+    DatePipe,
+  ]
+})
+
+export class RestrictedAccessPageModule {
+}

--- a/src/app/restricted-access/restricted-access.component.html
+++ b/src/app/restricted-access/restricted-access.component.html
@@ -1,0 +1,8 @@
+<div class="restricted-access container">
+  <h1>{{restrictedAccessHeader | async }}</h1>
+
+  <p>
+    {{restrictedAccessMessage | async }}
+  </p>
+
+</div>

--- a/src/app/restricted-access/restricted-access.component.ts
+++ b/src/app/restricted-access/restricted-access.component.ts
@@ -1,0 +1,91 @@
+import { DatePipe } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import * as _ from 'lodash';
+import { BehaviorSubject, Observable, windowWhen, zip } from 'rxjs';
+import { AuthService } from '../core/auth/auth.service';
+
+/**
+ * This component representing the `Restricted Access` DSpace page.
+ */
+@Component({
+  selector: 'ds-restricted-access',
+  templateUrl: './restricted-access.component.html',
+  styleUrls: ['./restricted-access.component.scss']
+})
+
+export class RestrictedAccessComponent implements OnInit {
+  /**
+   * The header to display
+   */
+  restrictedAccessHeader: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+
+  /**
+   * The message to display
+   */
+  restrictedAccessMessage: BehaviorSubject<string> = new BehaviorSubject<string>(null);
+
+  constructor(
+    private auth: AuthService,
+    private translateService: TranslateService,
+    private datePipe: DatePipe
+  ) {
+  }
+  ngOnInit(): void {
+    // Retrieve "restrictedAccess" parameter from history state,
+    // see https://medium.com/javascript-everyday/keep-data-in-the-state-object-during-navigation-in-angular-5657af156fb8
+    const { embargoRestriction } = window.history.state;
+
+    const isLoggedIn$ = this.auth.isAuthenticated();
+
+    isLoggedIn$.subscribe((isLoggedIn: boolean) => {
+      let header$: Observable<string>;
+      let message$: Observable<string>;
+
+      if (isLoggedIn) {
+        header$ = this.translateService.get('bitstream.restricted-access.user.forbidden.header', {});
+        message$  = this.translateService.get('bitstream.restricted-access.user.forbidden.message', {});
+      } else {
+        [header$, message$] = this.configureAnonymous(embargoRestriction);
+      }
+
+      zip(header$, message$).subscribe(([header, message]) => {
+        this.restrictedAccessHeader.next(header);
+        this.restrictedAccessMessage.next(message);
+      });
+    });
+  }
+
+  protected configureAnonymous(embargoRestriction: string): [Observable<string>, Observable<string>] {
+    let header$ = this.translateService.get('bitstream.restricted-access.header', {});
+    let message$: Observable<string>;
+
+    if (embargoRestriction == null) {
+      message$ = this.translateService.get('bitstream.restricted-access.anonymous.forbidden.message', {});
+    } else if (('FOREVER' === embargoRestriction)) {
+      message$ = this.translateService.get('bitstream.restricted-access.embargo.forever.message', {});
+    } else if (this.isValidDate(embargoRestriction)) {
+      let parsedDate = this.datePipe.transform(embargoRestriction, 'longDate');
+      message$ = this.translateService.get(
+        'bitstream.restricted-access.embargo.restricted-until.message', { 'restrictedAccessDate': parsedDate}
+      );
+    } else {
+      // Reach this branch when embargoRestriction is "NONE", but there is some
+      // other restriction, such as a "Campus" IP address group restiction.
+      message$ = this.translateService.get('bitstream.restricted-access.anonymous.forbidden.message', {});
+    }
+
+    return [header$, message$];
+  }
+
+  /**
+   * Returns true if the given String represents a valid date, false otherise.
+   *
+   * @param str the String to check.
+   * @true if the given String represents a valid date, false otherise.
+   */
+  private isValidDate(str: string): boolean {
+    // Expected date is in yyyy-MM-dd format.
+    return (str.match(/\d\d\d\d-\d\d-\d\d/) != null);
+  }
+}

--- a/src/app/restricted-access/restricted-access.component.ts
+++ b/src/app/restricted-access/restricted-access.component.ts
@@ -1,9 +1,18 @@
 import { DatePipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import * as _ from 'lodash';
-import { BehaviorSubject, Observable, windowWhen, zip } from 'rxjs';
+import { BehaviorSubject, combineLatest as observableCombineLatest, filter, map, Observable, of as observableOf, switchMap, take, zip } from 'rxjs';
 import { AuthService } from '../core/auth/auth.service';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { FeatureID } from '../core/data/feature-authorization/feature-id';
+import { RemoteData } from '../core/data/remote-data';
+import { HardRedirectService } from '../core/services/hard-redirect.service';
+import { redirectOn4xx } from '../core/shared/authorized.operators';
+import { Bitstream } from '../core/shared/bitstream.model';
+import { FileService } from '../core/shared/file.service';
+import { getRemoteDataPayload } from '../core/shared/operators';
+import { hasValue, isNotEmpty } from '../shared/empty.util';
 
 /**
  * This component representing the `Restricted Access` DSpace page.
@@ -25,40 +34,88 @@ export class RestrictedAccessComponent implements OnInit {
    */
   restrictedAccessMessage: BehaviorSubject<string> = new BehaviorSubject<string>(null);
 
+  bitstreamRD$: Observable<RemoteData<Bitstream>>;
+  bitstream$: Observable<Bitstream>;
+
   constructor(
+    private route: ActivatedRoute,
+    protected router: Router,
+    private authorizationService: AuthorizationDataService,
     private auth: AuthService,
+    private fileService: FileService,
+    private hardRedirectService: HardRedirectService,
     private translateService: TranslateService,
     private datePipe: DatePipe
   ) {
   }
   ngOnInit(): void {
-    // Retrieve "restrictedAccess" parameter from history state,
-    // see https://medium.com/javascript-everyday/keep-data-in-the-state-object-during-navigation-in-angular-5657af156fb8
-    const { embargoRestriction } = window.history.state;
+    this.bitstreamRD$ = this.route.data.pipe(
+      map((data) => data.bitstream));
 
-    const isLoggedIn$ = this.auth.isAuthenticated();
+    this.bitstream$ = this.bitstreamRD$.pipe(
+      redirectOn4xx(this.router, this.auth),
+      getRemoteDataPayload()
+    );
 
-    isLoggedIn$.subscribe((isLoggedIn: boolean) => {
-      let header$: Observable<string>;
-      let message$: Observable<string>;
-
-      if (isLoggedIn) {
-        header$ = this.translateService.get('bitstream.restricted-access.user.forbidden.header', {});
-        message$  = this.translateService.get('bitstream.restricted-access.user.forbidden.message', {});
+    this.bitstream$.pipe(
+      switchMap((bitstream: Bitstream) => {
+        const isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanDownload, isNotEmpty(bitstream) ? bitstream.self : undefined);
+        const isLoggedIn$ = this.auth.isAuthenticated();
+        return observableCombineLatest([isAuthorized$, isLoggedIn$, observableOf(bitstream)]);
+      }),
+      filter(([isAuthorized, isLoggedIn, bitstream]: [boolean, boolean, Bitstream]) => hasValue(isAuthorized) && hasValue(isLoggedIn)),
+      take(1),
+      switchMap(([isAuthorized, isLoggedIn, bitstream]: [boolean, boolean, Bitstream]) => {
+        if (isAuthorized) {
+          return this.fileService.retrieveFileDownloadLink(bitstream._links.content.href).pipe(
+            filter((fileLink) => hasValue(fileLink)),
+            take(1),
+            map((fileLink) => {
+              return [isAuthorized, isLoggedIn, bitstream, fileLink];
+            }));
+        } else {
+          return [[isAuthorized, isLoggedIn, bitstream, '']];
+        }
+      })
+    ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
+      if (isAuthorized && isNotEmpty(fileLink)) {
+        // This shouldn't happen, as the download is authorized, and the file link is available, so just redirect to
+        // actual download page.
+        this.hardRedirectService.redirect(fileLink);
       } else {
-        [header$, message$] = this.configureAnonymous(embargoRestriction);
-      }
+        let header$: Observable<string>;
+        let message$: Observable<string>;
 
-      zip(header$, message$).subscribe(([header, message]) => {
-        this.restrictedAccessHeader.next(header);
-        this.restrictedAccessMessage.next(message);
-      });
+        if (isLoggedIn) {
+          // This is a logged in user
+          header$ = this.translateService.get('bitstream.restricted-access.user.forbidden.header', {});
+
+          if (bitstream && bitstream.metadata['dc.title'] &&  bitstream.metadata['dc.title'][0] && bitstream.metadata['dc.title'][0].value) {
+            let filename = bitstream.metadata['dc.title'][0].value;
+            message$ = this.translateService.get(
+              'bitstream.restricted-access.user.forbidden.with_file.message', {'filename': filename});
+          } else {
+            message$ = this.translateService.get(
+              'bitstream.restricted-access.user.forbidden.generic.message', {});
+          }
+        } else {
+          // This is an anonymous user
+          [header$, message$] = this.configureAnonymous(bitstream);
+        }
+
+        zip(header$, message$).subscribe(([header, message]) => {
+          this.restrictedAccessHeader.next(header);
+          this.restrictedAccessMessage.next(message);
+          });
+      }
     });
   }
 
-  protected configureAnonymous(embargoRestriction: string): [Observable<string>, Observable<string>] {
+  protected configureAnonymous(bitstream: Bitstream): [Observable<string>, Observable<string>] {
     let header$ = this.translateService.get('bitstream.restricted-access.header', {});
     let message$: Observable<string>;
+
+    let embargoRestriction = bitstream.embargoRestriction;
 
     if (embargoRestriction == null) {
       message$ = this.translateService.get('bitstream.restricted-access.anonymous.forbidden.message', {});

--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.spec.ts
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.spec.ts
@@ -8,7 +8,9 @@ import { AuthorizationDataService } from '../../core/data/feature-authorization/
 import { HardRedirectService } from '../../core/services/hard-redirect.service';
 import { createSuccessfulRemoteDataObject } from '../remote-data.utils';
 import { ActivatedRoute, Router } from '@angular/router';
-import { getForbiddenRoute } from '../../app-routing-paths';
+// UMD Customization
+import { RESTRICTED_ACCESS_MODULE_PATH } from '../../app-routing-paths';
+// End UMD Customization
 import { TranslateModule } from '@ngx-translate/core';
 import { CommonModule } from '@angular/common';
 
@@ -133,9 +135,13 @@ describe('BitstreamDownloadPageComponent', () => {
         component = fixture.componentInstance;
         fixture.detectChanges();
       });
-      it('should navigate to the forbidden route', () => {
-        expect(router.navigateByUrl).toHaveBeenCalledWith(getForbiddenRoute(), {skipLocationChange: true});
+      // UMD Customization
+      it('should navigate to the restricted access route', () => {
+        expect(router.navigateByUrl).toHaveBeenCalledWith(
+         `${RESTRICTED_ACCESS_MODULE_PATH}/bitstreamUuid`, {replaceUrl: true}
+        );
       });
+      // End UMD Customization
     });
     describe('when the user is not authorized and not logged in', () => {
       beforeEach(waitForAsync(() => {
@@ -149,10 +155,13 @@ describe('BitstreamDownloadPageComponent', () => {
         component = fixture.componentInstance;
         fixture.detectChanges();
       });
-      it('should navigate to the login page', () => {
-        expect(authService.setRedirectUrl).toHaveBeenCalled();
-        expect(router.navigateByUrl).toHaveBeenCalledWith('login');
+      // UMD Customization
+      it('should navigate to the restricted access route', () => {
+        expect(router.navigateByUrl).toHaveBeenCalledWith(
+          `${RESTRICTED_ACCESS_MODULE_PATH}/bitstreamUuid`, {replaceUrl: true}
+        );
       });
+      // End UMD Customization
     });
   });
 });

--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
@@ -83,12 +83,16 @@ export class BitstreamDownloadPageComponent implements OnInit {
         this.hardRedirectService.redirect(fileLink);
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
+      // UMD Customization
       } else if (!isAuthorized && isLoggedIn) {
         // This can happen due to a "Campus" group IP restrictions
-        this.router.navigateByUrl(RESTRICTED_ACCESS_MODULE_PATH, { replaceUrl: true });
+        void this.router.navigateByUrl(
+          `${RESTRICTED_ACCESS_MODULE_PATH}/${bitstream.uuid}`,
+          { replaceUrl: true }
+        );
       } else if (!isAuthorized && !isLoggedIn) {
-        this.router.navigateByUrl(
-          RESTRICTED_ACCESS_MODULE_PATH, { replaceUrl: true, state: { embargoRestriction: bitstream.embargoRestriction } }
+        void this.router.navigateByUrl(`${RESTRICTED_ACCESS_MODULE_PATH}/${bitstream.uuid}`,
+          { replaceUrl: true }
         );
       // End UMD Customization
       }

--- a/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
+++ b/src/app/shared/bitstream-download-page/bitstream-download-page.component.ts
@@ -15,6 +15,10 @@ import { RemoteData } from '../../core/data/remote-data';
 import { redirectOn4xx } from '../../core/shared/authorized.operators';
 import { Location } from '@angular/common';
 
+// UMD Customization
+import { RESTRICTED_ACCESS_MODULE_PATH } from '../../app-routing-paths';
+// End UMD Customization
+
 @Component({
   selector: 'ds-bitstream-download-page',
   templateUrl: './bitstream-download-page.component.html'
@@ -80,10 +84,13 @@ export class BitstreamDownloadPageComponent implements OnInit {
       } else if (isAuthorized && !isLoggedIn) {
         this.hardRedirectService.redirect(bitstream._links.content.href);
       } else if (!isAuthorized && isLoggedIn) {
-        this.router.navigateByUrl(getForbiddenRoute(), {skipLocationChange: true});
+        // This can happen due to a "Campus" group IP restrictions
+        this.router.navigateByUrl(RESTRICTED_ACCESS_MODULE_PATH, { replaceUrl: true });
       } else if (!isAuthorized && !isLoggedIn) {
-        this.auth.setRedirectUrl(this.router.url);
-        this.router.navigateByUrl('login');
+        this.router.navigateByUrl(
+          RESTRICTED_ACCESS_MODULE_PATH, { replaceUrl: true, state: { embargoRestriction: bitstream.embargoRestriction } }
+        );
+      // End UMD Customization
       }
     });
   }

--- a/src/app/shared/file-download-link/file-download-link.component.html
+++ b/src/app/shared/file-download-link/file-download-link.component.html
@@ -6,3 +6,11 @@
 <ng-template #content>
   <ng-content></ng-content>
 </ng-template>
+
+<!-- UMD Customization -->
+<ng-template [ngIf]="(isEmbargoed$ |async)">
+  <br>
+  {{'bitstream.embargoed.text' | translate }}
+  <br>
+</ng-template>
+<!-- End UMD Customization -->

--- a/src/app/shared/file-download-link/file-download-link.component.spec.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.spec.ts
@@ -10,6 +10,17 @@ import { FeatureID } from '../../core/data/feature-authorization/feature-id';
 import { Item } from '../../core/shared/item.model';
 import { getItemModuleRoute } from '../../item-page/item-page-routing-paths';
 import { RouterLinkDirectiveStub } from '../testing/router-link-directive.stub';
+// UMD Customization
+import { Pipe, PipeTransform } from '@angular/core';
+
+// eslint-disable-next-line @angular-eslint/pipe-prefix
+@Pipe({ name: 'translate' })
+class MockTranslatePipe implements PipeTransform {
+  transform(value: string): string {
+    return value;
+  }
+}
+//End UMD Customization
 
 describe('FileDownloadLinkComponent', () => {
   let component: FileDownloadLinkComponent;
@@ -41,7 +52,9 @@ describe('FileDownloadLinkComponent', () => {
 
   function initTestbed() {
     TestBed.configureTestingModule({
-      declarations: [FileDownloadLinkComponent, RouterLinkDirectiveStub],
+      // UMD Customization
+      declarations: [FileDownloadLinkComponent, RouterLinkDirectiveStub, MockTranslatePipe],
+      // End UMD Customization
       providers: [
         {provide: AuthorizationDataService, useValue: authorizationService},
       ]

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -46,6 +46,10 @@ export class FileDownloadLinkComponent implements OnInit {
 
   canDownload$: Observable<boolean>;
 
+  // UMD Customization
+  isEmbargoed$: Observable<boolean>;
+  // End UMD Customization
+
   constructor(
     private authorizationService: AuthorizationDataService,
   ) {
@@ -62,6 +66,11 @@ export class FileDownloadLinkComponent implements OnInit {
       this.bitstreamPath$ = observableOf(this.getBitstreamDownloadPath());
       this.canDownload$ = observableOf(true);
     }
+    // UMD Customization
+    if (isNotEmpty(this.bitstream)) {
+      this.isEmbargoed$ = observableOf(this.bitstream.isEmbargoed());
+    }
+    // End UMD Customization
   }
 
   getBitstreamPath(canDownload: boolean, canRequestACopy: boolean) {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5129,5 +5129,22 @@
   "embargo-list.table.label.endDate": "End Date",
 
   "submission.sections.submit.progressbar.equitableAccessSubmission": "Equitable Access",
+
+  "bitstream.embargoed.text": "(RESTRICTED ACCESS)",
+
+  "bitstream.restricted-access.title": "This resource is restricted",
+
+  "bitstream.restricted-access.header": "Restricted Access",
+
+  "bitstream.restricted-access.embargo.forever.message": "At the request of the author, this document is not available.",
+
+  "bitstream.restricted-access.embargo.restricted-until.message": "At the request of the author, this document is not available until {{ restrictedAccessDate }}.",
+
+  "bitstream.restricted-access.anonymous.forbidden.message": "The file you are attempting to access is restricted.",
+
+  "bitstream.restricted-access.user.forbidden.header": "This bitstream is restricted",
+
+  "bitstream.restricted-access.user.forbidden.message": "You do not have the credentials to access this restricted bitstream."
+
   // End UMD Customization
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5144,7 +5144,9 @@
 
   "bitstream.restricted-access.user.forbidden.header": "This bitstream is restricted",
 
-  "bitstream.restricted-access.user.forbidden.message": "You do not have the credentials to access this restricted bitstream."
+  "bitstream.restricted-access.user.forbidden.with_file.message": "You do not have the credentials to access the restricted bitstream '{{ filename }}'.",
+
+  "bitstream.restricted-access.user.forbidden.generic.message": "You do not have the credentials to access this restricted bitstream.",
 
   // End UMD Customization
 }

--- a/src/themes/drum/lazy-theme.module.ts
+++ b/src/themes/drum/lazy-theme.module.ts
@@ -59,6 +59,8 @@ import { EmbargoListPageModule } from '../../app/embargo-list/embargo-list-page.
 import { EtdUnitsModule } from 'src/app/etdunit-registry/etdunits.module';
 import { ItemPageComponent } from './app/item-page/simple/item-page.component';
 import { JsonLdDatasetComponent } from './app/item-page/json-ld/json-ld-dataset.component';
+import { RestrictedAccessPageModule } from 'src/app/restricted-access/restricted-access-page.module';
+
 
 const DECLARATIONS = [
   ItemPageComponent,
@@ -115,6 +117,7 @@ const DECLARATIONS = [
     ComcolModule,
     EmbargoListPageModule,
     EtdUnitsModule,
+    RestrictedAccessPageModule,
   ],
   declarations: DECLARATIONS,
 })


### PR DESCRIPTION
Added "embargoRestriction" field to "BitstreamModel' (corresponding
to the changes to the "BItstreamRest" model on the back-end, that
contains one of the following strings, based on the embargo status of the
bitstream:

* "NONE" - no embargo (or embargo on item has been lifted)
* "FOREVER" - the embargo never ends
* A date (in yyyy-MM-dd) format, indicating the embargo lift date

Displays a "(RESTRICTED ACCESS)" text marker below the download link
whenever the bitstream has an active embargo (shown for all users, even
if the user can actually download the bitstream).

Added a "restricted-access" module that shows the "Restricted Access"
page when a bitstream is embargoed, or otherwise not downloadable by
the user (such as due to a "Campus" IP restriction, and the user is
off-campus).

The "Restricted Access" page show differing text based on whether the
file has a time-limited embargo, a forever embargo, the user is logged
in, or if there is some other (non-embargo) restriction.

Modified the "BitstreamDownloadPageComponent" to navigate to the
"Restricted Access" page when user clicks on a link that they
are unable to download, and include the bitstream
UUID in the URL, so that it can be used to retrieve the bitstream information.

Modified the "RestrictedAccessPageRoutingModule" to use the
BitstreamPageResolver to retrieve the bitstream so that information
about the bitstream (such as embargo date or filename) can be used in
the restricted access page.

https://umd-dit.atlassian.net/browse/LIBDRUM-678