### PR TITLE
LIBDRUM-740. Reorganize simple item display

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5092,9 +5092,13 @@
 
   "item.page.advisor": "Advisor",
 
+  "item.page.citation.datasetOrSoftware": "Related Publication Citation",
+
   "item.page.doi": "DRUM DOI",
 
-  "item.page.publicationlink": "Publication or External Link",
+  "item.page.publicationLink": "Publication or External Link",
+
+  "item.page.publicationLink.datasetOrSoftware": "Related Publication Link",
 
   "item.page.rights": "Rights",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5090,9 +5090,13 @@
   // UMD Customization
   "menu.header.organization.logo": "UMD Libraries",
 
+  "item.page.advisor": "Advisor",
+
   "item.page.doi": "DRUM DOI",
 
-  "item.page.advisor": "Advisor",
+  "item.page.publicationlink": "Publication or External Link",
+
+  "item.page.rights": "Rights",
 
   "community_group.faculty.title": "Collections Organized by Department",
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5094,6 +5094,8 @@
 
   "item.page.citation.datasetOrSoftware": "Related Publication Citation",
 
+  "item.page.description": "Notes",
+
   "item.page.doi": "DRUM DOI",
 
   "item.page.publicationLink": "Publication or External Link",
@@ -5101,6 +5103,8 @@
   "item.page.publicationLink.datasetOrSoftware": "Related Publication Link",
 
   "item.page.rights": "Rights",
+
+  "item.page.uri": "URI (handle)",
 
   "community_group.faculty.title": "Collections Organized by Department",
 

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -46,19 +46,6 @@
       [label]="'relationships.isAuthorOf' | translate">
     </ds-metadata-representation-list>
 
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['journal.title']"
-      [label]="'item.page.journal-title'">
-    </ds-generic-item-page-field>
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['journal.identifier.issn']"
-      [label]="'item.page.journal-issn'">
-    </ds-generic-item-page-field>
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['journalvolume.identifier.name']"
-      [label]="'item.page.volume-title'">
-    </ds-generic-item-page-field>
-
     <!-- Advisor -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.contributor.advisor']"
@@ -75,12 +62,7 @@
     <ds-item-page-uri-field [item]="object"
       [fields]="['dc.identifier']"
       [label]="'item.page.doi'">
-
     </ds-item-page-uri-field>
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['dc.publisher']"
-      [label]="'item.page.publisher'">
-    </ds-generic-item-page-field>
   </div>
   <div class="col-xs-12 col-md-6">
     <!-- Right column -->
@@ -92,12 +74,6 @@
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"
       [label]="'item.page.description'">
-    </ds-generic-item-page-field>
-
-    <ds-generic-item-page-field [item]="object"
-      [fields]="['dc.subject']"
-      [separator]="','"
-      [label]="'item.page.subject'">
     </ds-generic-item-page-field>
 
     <!-- URI (handle) -->

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -35,6 +35,12 @@
     </ng-container>
     <ds-themed-item-page-file-section [item]="object"></ds-themed-item-page-file-section>
 
+    <!-- Publication or External Link -->
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['dc.description.uri']"
+      [label]="'item.page.publicationlink'">
+    </ds-item-page-uri-field>
+
     <!-- Date -->
     <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
 
@@ -81,6 +87,12 @@
       [fields]="['dc.identifier.uri']"
       [label]="'item.page.uri'">
     </ds-item-page-uri-field>
+
+    <!-- Rights -->
+    <ds-generic-item-page-field [item]="object"
+      [fields]="['dc.rights', 'dc.rights.uri']"
+      [label]="'item.page.rights'">
+    </ds-generic-item-page-field>
 
     <!-- Collection -->
     <ds-item-page-collections [item]="object"></ds-item-page-collections>

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -8,9 +8,11 @@
   </div>
 </div>
 <div class="d-flex flex-row">
+  <!-- Title -->
   <h2 class="item-page-title-field mr-auto">
     <ds-metadata-values [mdValues]="object?.allMetadata(['dc.title'])"></ds-metadata-values>
   </h2>
+
   <div class="pl-2">
     <ds-dso-page-version-button (newVersionEvent)="onCreateNewVersion()" [dso]="object"
                                 [tooltipMsgCreate]="'item.page.version.create'"
@@ -20,6 +22,9 @@
 </div>
 <div class="row">
   <div class="col-xs-12 col-md-4">
+    <!-- Left column -->
+
+    <!-- Files -->
     <ng-container *ngIf="!mediaViewer.image">
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
         <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
@@ -29,13 +34,18 @@
       <ds-media-viewer [item]="object" [videoOptions]="mediaViewer.video"></ds-media-viewer>
     </ng-container>
     <ds-themed-item-page-file-section [item]="object"></ds-themed-item-page-file-section>
+
+    <!-- Date -->
     <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
+
+    <!-- Authors -->
     <ds-metadata-representation-list class="ds-item-page-mixed-author-field"
       [parentItem]="object"
       [itemType]="'Person'"
       [metadataFields]="['dc.contributor.author', 'dc.creator']"
       [label]="'relationships.isAuthorOf' | translate">
     </ds-metadata-representation-list>
+
     <ds-generic-item-page-field [item]="object"
       [fields]="['journal.title']"
       [label]="'item.page.journal-title'">
@@ -48,17 +58,24 @@
       [fields]="['journalvolume.identifier.name']"
       [label]="'item.page.volume-title'">
     </ds-generic-item-page-field>
+
+    <!-- Advisor -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.contributor.advisor']"
       [label]="'item.page.advisor'">
     </ds-generic-item-page-field>
+
+    <!-- Citation -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.identifier.citation']"
       [label]="'item.page.citation'">
     </ds-generic-item-page-field>
+
+    <!-- DRUM DOI -->
     <ds-item-page-uri-field [item]="object"
       [fields]="['dc.identifier']"
       [label]="'item.page.doi'">
+
     </ds-item-page-uri-field>
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.publisher']"
@@ -66,7 +83,12 @@
     </ds-generic-item-page-field>
   </div>
   <div class="col-xs-12 col-md-6">
+    <!-- Right column -->
+
+    <!-- Abstract -->
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
+
+    <!-- Notes -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"
       [label]="'item.page.description'">
@@ -77,11 +99,16 @@
       [separator]="','"
       [label]="'item.page.subject'">
     </ds-generic-item-page-field>
+
+    <!-- URI (handle) -->
     <ds-item-page-uri-field [item]="object"
       [fields]="['dc.identifier.uri']"
       [label]="'item.page.uri'">
     </ds-item-page-uri-field>
+
+    <!-- Collection -->
     <ds-item-page-collections [item]="object"></ds-item-page-collections>
+
     <div>
       <a class="btn btn-outline-primary" [routerLink]="[itemPageRoute + '/full']" role="button">
         <i class="fas fa-info-circle"></i> {{"item.page.link.full" | translate}}

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -38,7 +38,7 @@
     <!-- Publication or External Link -->
     <ds-item-page-uri-field [item]="object"
       [fields]="['dc.description.uri']"
-      [label]="'item.page.publicationlink'">
+      [label]="publicationLinkLabelI18nKey">
     </ds-item-page-uri-field>
 
     <!-- Date -->
@@ -61,7 +61,7 @@
     <!-- Citation -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.identifier.citation']"
-      [label]="'item.page.citation'">
+      [label]="citationLabelI18nKey">
     </ds-generic-item-page-field>
 
     <!-- DRUM DOI -->

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { UntypedItemComponent as BaseComponent } from '../../../../../../../app/item-page/simple/item-types/untyped-item/untyped-item.component';
 import { Item } from '../../../../../../../app/core/shared/item.model';
 import { ViewMode } from '../../../../../../../app/core/shared/view-mode.model';
@@ -16,6 +16,19 @@ import { Context } from 'src/app/core/shared/context.model';
   templateUrl: './untyped-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UntypedItemComponent extends BaseComponent {
+export class UntypedItemComponent extends BaseComponent implements OnInit {
+  public publicationLinkLabelI18nKey = 'item.page.publicationLink';
+  public citationLabelI18nKey = 'item.page.citation';
 
+  ngOnInit(): void {
+    super.ngOnInit();
+
+    let itemType: string = this.object.firstMetadataValue('dc.type');
+
+    if (('Dataset' === itemType) || ('Software' === itemType)) {
+      // Change labels for Dataset/Software items
+      this.publicationLinkLabelI18nKey = 'item.page.publicationLink.datasetOrSoftware';
+      this.citationLabelI18nKey = 'item.page.citation.datasetOrSoftware';
+    }
+  }
 }


### PR DESCRIPTION
Modified the "simple item" display as described in the issue.

The dynamic label changes are handled in the “ngOnInit” method
of the “UntypedItemComponent” class, which passes the appropriate
I18n key for the “dc.description.uri” and “dc.identifier.citation” based
on whether the item type is “Dataset” or “Software” or something else.

https://umd-dit.atlassian.net/browse/LIBDRUM-740