### PR TITLE
LIBDRUM-734. Switch order of log in options on Log In menu

### DIFF
--- a/src/app/core/auth/auth.interceptor.ts
+++ b/src/app/core/auth/auth.interceptor.ts
@@ -115,18 +115,24 @@ export class AuthInterceptor implements HttpInterceptor {
    * @param authMethodModels
    */
   private sortAuthMethods(authMethodModels: AuthMethod[]): AuthMethod[] {
+    // UMD Customization
+    // Modified to move "CAS" login option (instead of "password" to be the
+    // first authMethod, so that it appears first in the "Login" drop-down
+    let firstAuthMethodType: AuthMethodType = AuthMethodType.Cas;
+
     const sortedAuthMethodModels: AuthMethod[] = [];
     authMethodModels.forEach((method) => {
-      if (method.authMethodType === AuthMethodType.Password) {
+      if (method.authMethodType === firstAuthMethodType) {
         sortedAuthMethodModels.push(method);
       }
     });
 
     authMethodModels.forEach((method) => {
-      if (method.authMethodType !== AuthMethodType.Password) {
+      if (method.authMethodType !== firstAuthMethodType) {
         sortedAuthMethodModels.push(method);
       }
     });
+    // End UMD Customization
 
     return sortedAuthMethodModels;
   }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -2830,12 +2830,14 @@
   "login.form.password": "Password",
 
   // UMD Customization
-  "login.form.cas": "Log in with CAS",
+  "login.form.cas": "UMD Login",
   // End  UMD Customization
 
   "login.form.shibboleth": "Log in with Shibboleth",
 
-  "login.form.submit": "Log in",
+  // UMD Customization
+  "login.form.submit": "Guest Researcher Login",
+  // End UMD Customization
 
   "login.title": "Login",
 


### PR DESCRIPTION
Modified the "AuthInterceptor" class to place the "CAS" authentication method as the first entry in the sorted array, instead of "password". This ensures that that the "CAS" option will appear first in the "LoginComponent" drop-down list.

Modified button labels in the "en.json5" file to match the requests in the issue.

https://umd-dit.atlassian.net/browse/LIBDRUM-734
