### PR TITLE
LIBDRUM-751. Limit "RESTRICTED ACCESS" marker display to existing items

### DIFF
--- a/src/app/core/shared/bitstream.model.ts
+++ b/src/app/core/shared/bitstream.model.ts
@@ -89,6 +89,12 @@ export class Bitstream extends DSpaceObject implements ChildHALResource {
    * false otherwise.
    */
   isEmbargoed() {
-    return 'NONE' !== this.embargoRestriction;
+    if (this.embargoRestriction === undefined) {
+      // This is a "new" bitstream (i.e. just uploaded for a submission), so
+      // simply return false
+      return false;
+    } else {
+      return 'NONE' !== this.embargoRestriction;
+    }
   }
 }


### PR DESCRIPTION
Fixed an issue where the "(RESTRICTED ACCESS)" marker was being displayed on the submission form for newly uploaded items.

Modified the "isEmbargoed()" method to return false if the "embargoRestriction" field is undefined, which it will be for a newly uploaded file on the submission form.

https://umd-dit.atlassian.net/browse/LIBDRUM-751

## References
_Add references/links to any related issues or PRs. These may include:_
* Fixes #[issue-number]
* Requires DSpace/DSpace#[pr-number] (if a REST API PR is required to test this)

## Description
Short summary of changes (1-2 sentences).

## Instructions for Reviewers
Please add a more detailed description of the changes made by your PR. At a minimum, providing a bulleted list of changes in your PR is helpful to reviewers.

List of changes in this PR:
* First, ...
* Second, ...

**Include guidance for how to test or review your PR.** This may include: steps to reproduce a bug, screenshots or description of a new feature, or reasons behind specific changes. 

## Checklist
_This checklist provides a reminder of what we are going to look for when reviewing your PR. You need not complete this checklist prior to creating your PR (draft PRs are always welcome). If you are unsure about an item in the checklist, don't hesitate to ask. We're here to help!_

- [ ] My PR is small in size (e.g. less than 1,000 lines of code, not including comments & specs/tests), or I have provided reasons as to why that's not possible.
- [ ] My PR passes [TSLint](https://palantir.github.io/tslint/) validation using `yarn run lint`
- [ ] My PR doesn't introduce circular dependencies
- [ ] My PR includes [TypeDoc](https://typedoc.org/) comments for _all new (or modified) public methods and classes_. It also includes TypeDoc for large or complex private methods.
- [ ] My PR passes all specs/tests and includes new/updated specs or tests based on the [Code Testing Guide](https://wiki.lyrasis.org/display/DSPACE/Code+Testing+Guide).
- [ ] If my PR includes new, third-party dependencies (in `package.json`), I've made sure their licenses align with the [DSpace BSD License](https://github.com/DSpace/DSpace/blob/main/LICENSE) based on the [Licensing of Contributions](https://wiki.lyrasis.org/display/DSPACE/Code+Contribution+Guidelines#CodeContributionGuidelines-LicensingofContributions) documentation.
