### PR TITLE
LIBDRUM-761. Updated DRUM home page text and image

### DIFF
--- a/src/themes/drum/app/home-page/home-news/home-news.component.html
+++ b/src/themes/drum/app/home-page/home-news/home-news.component.html
@@ -1,0 +1,47 @@
+<div class="background-image-container">
+  <div class="container">
+    <div class="jumbotron jumbotron-fluid">
+      <div class="d-flex flex-wrap">
+        <div>
+          <p class="lead" style="font-weight: bold;">
+            Welcome to the repository for University of Maryland research.
+          </p>
+        </div>
+      </div>
+      <p>
+        The Digital Repository at the University of Maryland (DRUM) collects,
+        preserves, and provides public access to the scholarly output of the
+        university. Faculty and researchers can upload research products for
+        rapid dissemination, global visibility and impact, and long-term
+        preservation.
+      </p>
+      <ul>
+        <li>
+          Faculty may use DRUM to fulfill the
+          <a href="https://policies.umd.edu/research/university-of-maryland-policy-for-equitable-access-to-scholarly-articles-authored-by-university-faculty">
+            Equitable Access to Scholarly Articles Authored by University Faculty
+          </a>
+          policy, and in many cases may use it to fulfill open access requirements
+          from grant funding agencies.
+        </li>
+        <li>
+          Departments can use DRUM to publish or distribute their working
+          papers, technical reports, or other research material.
+        </li>
+        <li>
+          DRUM also includes all UMD theses and dissertations from 2003 forward.
+        </li>
+      </ul>
+      <p>
+        To learn more about DRUM, and how you can make your research openly
+        accessible to the public, visit our
+        <a href="https://www.lib.umd.edu/research/drum">
+          DRUM policies website.
+        </a>
+      </p>
+    </div>
+  </div>
+  <picture class="background-image">
+    <img alt="" [src]="'assets/drum/images/drum-background-image.jpg'"/><!-- without the []="''" Firefox downloads both the fallback and the resolved image -->
+  </picture>
+</div>

--- a/src/themes/drum/app/home-page/home-news/home-news.component.scss
+++ b/src/themes/drum/app/home-page/home-news/home-news.component.scss
@@ -1,0 +1,93 @@
+// This file is based on src/themes/dspace/app/home-page/home-news/home-news.component.scss
+:host {
+  display: block;
+  margin-top: calc(var(--ds-content-spacing) * -1);
+
+  div.background-image-container {
+    color: white;
+    position: relative;
+
+    .background-image > img {
+      // UMD Customization
+      background-color: #e21833; // "Maryland Red", see https://brand.umd.edu/colors
+      // End UMD Customization
+      position: absolute;
+      z-index: -1;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: top;
+    }
+
+    .container {
+      position: relative;
+      text-shadow: 1px 1px 4px rgba(0, 0, 0, 0.6);
+
+      &:before, &:after {
+        content: '';
+        display: block;
+        width: var(--ds-banner-background-gradient-width);
+        height: 100%;
+        top: 0;
+        position: absolute;
+      }
+
+      &:before {
+        background: linear-gradient(to left, var(--ds-banner-text-background), transparent);
+        left: calc(-1 * var(--ds-banner-background-gradient-width));
+
+      }
+
+      &:after {
+        background: linear-gradient(to right, var(--ds-banner-text-background), transparent);
+        right: calc(-1 * var(--ds-banner-background-gradient-width));
+      }
+
+      background-color: var(--ds-banner-text-background);
+    }
+
+
+    small.credits {
+      a {
+        color: inherit;
+      }
+
+      opacity: 0.3;
+      position: absolute;
+      right: var(--bs-spacer);
+      bottom: 0;
+    }
+  }
+
+  .jumbotron {
+    background-color: transparent;
+
+    // UMD Customization
+    // Increase font sizes in "hero image" by 20%
+    p.lead {
+      font-size: 1.5rem;
+    }
+
+
+    p {
+      font-size: 1.2rem;
+    }
+
+    ul {
+      font-size: 1.2rem;
+    }
+    // End UMD Customization
+  }
+
+  a {
+    color: var(--ds-home-news-link-color);
+
+    @include hover {
+      color: var(--ds-home-news-link-hover-color);
+    }
+  }
+}
+
+

--- a/src/themes/drum/app/home-page/home-news/home-news.component.ts
+++ b/src/themes/drum/app/home-page/home-news/home-news.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { HomeNewsComponent as BaseComponent } from '../../../../../app/home-page/home-news/home-news.component';
+
+@Component({
+  selector: 'ds-home-news',
+  styleUrls: ['./home-news.component.scss'],
+  templateUrl: './home-news.component.html'
+})
+
+/**
+ * Component to render the news section on the home page
+ */
+export class HomeNewsComponent extends BaseComponent {}
+

--- a/src/themes/drum/app/navbar/navbar.component.scss
+++ b/src/themes/drum/app/navbar/navbar.component.scss
@@ -1,6 +1,8 @@
 nav.navbar {
   border-top: 1px var(--ds-header-navbar-border-top-color) solid;
-  border-bottom: 5px var(--bs-green) solid;
+  // UMD Customization
+  border-bottom: 5px #454545 solid;
+  // End UMD Customization
   align-items: baseline;
   color: var(--ds-header-icon-color);
 }

--- a/src/themes/drum/eager-theme.module.ts
+++ b/src/themes/drum/eager-theme.module.ts
@@ -21,6 +21,7 @@ import { CommunityListComponent } from './app/community-list-page/community-list
 import { CommunityListPageComponent } from './app/community-list-page/community-list-page.component';
 import { HomePageModule } from 'src/app/home-page/home-page.module';
 import { JsonLdWebsiteComponent } from './app/item-page/json-ld/json-ld-website.component';
+import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
 
 /**
  * Declaration needed to make sure all decorator functions are called in time
@@ -50,6 +51,7 @@ const DECLARATIONS = [
   CommunityListPageComponent,
   CommunityListComponent,
   HomePageComponent,
+  HomeNewsComponent,
   JsonLdWebsiteComponent,
 ];
 

--- a/src/themes/drum/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/drum/styles/_theme_css_variable_overrides.scss
@@ -4,4 +4,8 @@
 @import '../../dspace/styles/_theme_css_variable_overrides.scss';
 
 // Customizations for "drum" theme
+:root {
+  --ds-home-news-link-color: #ffd200; // "Maryland Gold", see https://brand.umd.edu/colors
+  --ds-home-news-link-hover-color: #ffd200;
+}
 


### PR DESCRIPTION
* Moved "HomeNewsComponent" into the "drum" theme
* Updated "hero image" text for DRUM
* Replaced background image
* Increased the font size of the text t in the “hero image” by 20%
* Changed the hyperlinks in the hero image text to “Maryland Gold” (#ffd200) from the the UMD palette (https://brand.umd.edu/colors )
* Change the bar between the navigation bar and the hero image to dark gray (#454545)

https://umd-dit.atlassian.net/browse/LIBDRUM-761
