### PR TITLE
LIBDRUM-746. Removed "preserve-line-breaks" on Item page metadata fields

### DIFF
--- a/src/app/item-page/field-components/metadata-values/metadata-values.component.html
+++ b/src/app/item-page/field-components/metadata-values/metadata-values.component.html
@@ -1,7 +1,9 @@
 <ds-metadata-field-wrapper [label]="label | translate">
     <ng-container *ngFor="let mdValue of mdValues; let last=last;">
-      <ng-container *ngTemplateOutlet="(renderMarkdown ? markdown : simple); context: {value: mdValue.value, classes: 'dont-break-out preserve-line-breaks'}">
-      </ng-container>
+      <!-- UMD Customization -->
+      <ng-container *ngTemplateOutlet="(renderMarkdown ? markdown : simple); context: {value: mdValue.value, classes: 'dont-break-out'}">
+      <!-- End UMD Customization -->
+    </ng-container>
       <span class="separator" *ngIf="!last" [innerHTML]="separator"></span>
     </ng-container>
 </ds-metadata-field-wrapper>


### PR DESCRIPTION
Modified the metadata field display on the "Item" page by removing the "preserve-line-breaks" CSS class, so that the multi-line "Abstract" and "Notes" fields are displayed as single blocks of text, ignoring any line breaks in the text. This is to make the display more similar to that of DSpace 6, which had the same behavior.

Without this change, the "Abstract" and "Notes" fields of many items displayed oddly, because the line breaks were not compatible with the available display width, leading to many short line fragments.

https://umd-dit.atlassian.net/browse/LIBDRUM-746
