### PR TITLE
LIBDRUM-785. Change homepage to 2-column layout of communities/recent submissions

### DIFF
--- a/src/app/home-page/recent-item-list/recent-item-list.component.html
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.html
@@ -1,6 +1,8 @@
 <ng-container *ngVar="(itemRD$ | async) as itemRD">
-        <div class="mt-4" [ngClass]="placeholderFontClass" *ngIf="itemRD?.hasSucceeded && itemRD?.payload?.page.length > 0" @fadeIn>
-                <div class="d-flex flex-row border-bottom mb-4 pb-4 ng-tns-c416-2"></div>
+        <!-- UMD Customization -->
+        <div class="mt-4 mt-sm-0" [ngClass]="placeholderFontClass" *ngIf="itemRD?.hasSucceeded && itemRD?.payload?.page.length > 0" @fadeIn>
+                <div class="d-xs-block d-sm-none d-flex flex-row border-bottom mb-4 pb-4 ng-tns-c416-2"></div>
+        <!-- End UMD Customizaton -->
                 <h2> {{'home.recent-submissions.head' | translate}}</h2>
                 <div class="my-4" *ngFor="let item of itemRD?.payload?.page">
                         <ds-listable-object-component-loader [object]="item" [viewMode]="viewMode" class="pb-4">

--- a/src/themes/drum/app/home-page/home-page.component.html
+++ b/src/themes/drum/app/home-page/home-page.component.html
@@ -11,7 +11,7 @@
       <h3>{{ 'community_group.faculty.title' | translate }}</h3>
       <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
       </ds-cg-community-list>
-      <h3>{{ 'community_group.um.title' | translate }}</h3>
+      <h3 class="mt-4">{{ 'community_group.um.title' | translate }}</h3>
       <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
       </ds-cg-community-list>
     </div>

--- a/src/themes/drum/app/home-page/home-page.component.html
+++ b/src/themes/drum/app/home-page/home-page.component.html
@@ -5,12 +5,18 @@
   </ng-container>
   <ds-search-form [inPlaceSearch]="false" [searchPlaceholder]="'home.search-form.placeholder' | translate">
   </ds-search-form>
-  <h2>{{ 'communityList.title' | translate }}</h2>
-  <h3>{{ 'community_group.faculty.title' | translate }}</h3>
-  <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
-  </ds-cg-community-list>
-  <h3>{{ 'community_group.um.title' | translate }}</h3>
-  <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
-  </ds-cg-community-list>
-  <ds-recent-item-list *ngIf="recentSubmissionspageSize>0"></ds-recent-item-list>
+  <div class="row">
+    <div class="col-sm-6">
+      <h2>{{ 'communityList.title' | translate }}</h2>
+      <h3>{{ 'community_group.faculty.title' | translate }}</h3>
+      <ds-cg-community-list [communityGroupId]="FACULTY_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
+      </ds-cg-community-list>
+      <h3>{{ 'community_group.um.title' | translate }}</h3>
+      <ds-cg-community-list [communityGroupId]="UM_COMMUNITY_GROUP" [size]="COMMUNITY_LIST_SIZE">
+      </ds-cg-community-list>
+    </div>
+    <div class="col-sm-6">
+      <ds-recent-item-list *ngIf="recentSubmissionspageSize>0"></ds-recent-item-list>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
Modified the home page to show "List of Communities" and
"Recent Submissions" in a two-column layout.

The 2-column implementation required making changes to the stock
DSpace “recent-item-list” component, which is not themeable. Therefore,
the stock DSpace file
“src/app/home-page/recent-item-list/recent-item-list.component.html”
was customized in-place. The change in the file was adding Bootstrap
tags to suppress the margin top and dividing line in the “small” layouts
and above, so that the  “Recent Submissions” title in the second column
would line up with the “List of Communities” title  in the first column.

The “src/themes/drum/app/home-page/home-page.component.html” was also
modified to place the “List of Communities” and “Recent Submissions”
into a two-column layout, using Bootstrap grid functionality.

Also, modified “src/themes/drum/app/home-page/home-page.component.html” to
add a little more space between the "Collections Organized by
Department" and "UM Community-managed Collections" sublists in the
"Communities" list, so that the "Show More" button of the first list
is not so close to the title of the second list.

https://umd-dit.atlassian.net/browse/LIBDRUM-785