### PR TITLE
LIBDRUM-787. Implementation of "health-ping" static HTML page

### DIFF
--- a/src/themes/drum/assets/static-pages/health-ping.html
+++ b/src/themes/drum/assets/static-pages/health-ping.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <base href="/">
+    <title>DRUM - Application Health Check</title>
+    <meta name="viewport" content="width=device-width,minimum-scale=1">
+  </head>
+
+  <body>
+    <h1>Application Health Check</h1>
+    <p>Application is OK</p>
+  </body>
+</html>


### PR DESCRIPTION
Simplest possible implementation of a "health-ping" page, using an HTML page stored as part of the assets.

The endpoint is "/assets/drum/static-pages/health-ping.html"

https://umd-dit.atlassian.net/browse/LIBDRUM-787
