### PR TITLE
LIBDRUM-808. Initial implementation of Matomo Analytics

### DIFF
--- a/src/app/core/shared/search/search.service.ts
+++ b/src/app/core/shared/search/search.service.ts
@@ -346,6 +346,11 @@ export class SearchService implements OnDestroy {
       action: 'search',
       properties: {
         searchOptions: config,
+        // UMD Customization
+        // Matomo analytics requires a "category" property, unlike
+        // Google Analytics which sets the category to "Event" by default
+        category: 'Event',
+        // End UMD Customization
         page: {
           size: config.pagination.size, // same as searchQueryResponse.page.elementsPerPage
           totalElements: searchQueryResponse.pageInfo.totalElements,

--- a/src/app/statistics/angulartics/dspace/view-tracker.component.ts
+++ b/src/app/statistics/angulartics/dspace/view-tracker.component.ts
@@ -21,7 +21,11 @@ export class ViewTrackerComponent implements OnInit {
   ngOnInit(): void {
     this.angulartics2.eventTrack.next({
       action: 'pageView',
-      properties: {object: this.object},
+      // UMD Customization
+      // Matomo analytics requires a "category" property, unlike
+      // Google Analytics which sets the category to "Event" by default
+      properties: {object: this.object, category: 'Event'},
+      // End UMD Customization
     });
   }
 }

--- a/src/app/statistics/matomo-analytics.service.ts
+++ b/src/app/statistics/matomo-analytics.service.ts
@@ -1,0 +1,83 @@
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
+
+import { Angulartics2Matomo } from 'angulartics2';
+import { combineLatest } from 'rxjs';
+
+import { ConfigurationDataService } from '../core/data/configuration-data.service';
+import { getFirstCompletedRemoteData } from '../core/shared/operators';
+import { isEmpty } from '../shared/empty.util';
+import { KlaroService } from '../shared/cookies/klaro.service';
+import { GOOGLE_ANALYTICS_KLARO_KEY } from '../shared/cookies/klaro-configuration';
+
+/**
+ * Set up Matomo Analytics on the client side.
+ * See: {@link addTrackingIdToPage}.
+ */
+@Injectable()
+export class MatomoAnalyticsService {
+
+  constructor(
+    private matomoAnalytics: Angulartics2Matomo,
+    // private klaroService: KlaroService,
+    private configService: ConfigurationDataService,
+    @Inject(DOCUMENT) private document: any,
+  ) {
+  }
+
+  /**
+   * Call this method once when Angular initializes on the client side.
+   * It requests the Matomo tracking propertiesfrom the rest backend
+   * adds the tracking snippet to the page and starts tracking.
+   */
+  addTrackingIdToPage(): void {
+    const matomo_url_rd$ = this.configService.findByPropertyName('matomo.analytics.url').pipe(
+        getFirstCompletedRemoteData(),
+    );
+    const matomo_site_id_rd$ = this.configService.findByPropertyName('matomo.analytics.site-id').pipe(
+      getFirstCompletedRemoteData(),
+    );
+    const matomo_cdn_src_rd$ = this.configService.findByPropertyName('matomo.analytics.cdn-src').pipe(
+      getFirstCompletedRemoteData(),
+    );
+
+    combineLatest([matomo_url_rd$, matomo_site_id_rd$, matomo_cdn_src_rd$])
+      .subscribe(([matomo_url_rd, matomo_site_id_rd, matomo_cdn_src_rd]) => {
+
+        // make sure we got a success response from the backend
+        if (matomo_url_rd.hasFailed || matomo_site_id_rd.hasFailed || matomo_cdn_src_rd.hasFailed) {
+          return;
+        }
+
+        const matomo_url = matomo_url_rd.payload.values[0];
+        const  matomo_site_id =  matomo_site_id_rd.payload.values[0];
+        const matomo_cdn_src = matomo_cdn_src_rd.payload.values[0];
+
+        // Make sure we have valid values for all the properties
+        if (isEmpty(matomo_url) || isEmpty(matomo_site_id) || isEmpty(matomo_cdn_src)) {
+          return;
+        }
+
+        // add Matomo tracking snippet to page
+        const keyScript = this.document.createElement('script');
+        keyScript.innerHTML =
+          `
+          var _paq = window._paq = window._paq || [];
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="${matomo_url}";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '${matomo_site_id}']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src='${matomo_cdn_src}'; s.parentNode.insertBefore(g,s);
+          })();
+          `;
+          this.document.head.appendChild(keyScript);
+
+          // start tracking
+          this.matomoAnalytics.startTracking();
+      });
+  }
+}

--- a/src/modules/app/browser-app.module.ts
+++ b/src/modules/app/browser-app.module.ts
@@ -28,7 +28,7 @@ import {
 } from '../../app/core/services/browser-hard-redirect.service';
 import { LocaleService } from '../../app/core/locale/locale.service';
 import { GoogleAnalyticsService } from '../../app/statistics/google-analytics.service';
-import { MatomoAnalyticsService } from 'src/app/statistics/matomo-analytics.service';
+import { MatomoAnalyticsService } from '../../app/statistics/matomo-analytics.service';
 import { AuthRequestService } from '../../app/core/auth/auth-request.service';
 import { BrowserAuthRequestService } from '../../app/core/auth/browser-auth-request.service';
 import { BrowserInitService } from './browser-init.service';

--- a/src/modules/app/browser-app.module.ts
+++ b/src/modules/app/browser-app.module.ts
@@ -28,6 +28,7 @@ import {
 } from '../../app/core/services/browser-hard-redirect.service';
 import { LocaleService } from '../../app/core/locale/locale.service';
 import { GoogleAnalyticsService } from '../../app/statistics/google-analytics.service';
+import { MatomoAnalyticsService } from 'src/app/statistics/matomo-analytics.service';
 import { AuthRequestService } from '../../app/core/auth/auth-request.service';
 import { BrowserAuthRequestService } from '../../app/core/auth/browser-auth-request.service';
 import { BrowserInitService } from './browser-init.service';
@@ -98,6 +99,10 @@ export function getRequest(transferState: TransferState): any {
     {
       provide: GoogleAnalyticsService,
       useClass: GoogleAnalyticsService,
+    },
+    {
+      provide: MatomoAnalyticsService,
+      useClass: MatomoAnalyticsService,
     },
     {
       provide: Angulartics2GoogleTagManager,

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -19,6 +19,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { LocaleService } from '../../app/core/locale/locale.service';
 import { Angulartics2DSpace } from '../../app/statistics/angulartics/dspace-provider';
 import { GoogleAnalyticsService } from '../../app/statistics/google-analytics.service';
+import { MatomoAnalyticsService } from '../../app/statistics/matomo-analytics.service';
 import { MetadataService } from '../../app/core/metadata/metadata.service';
 import { BreadcrumbsService } from '../../app/breadcrumbs/breadcrumbs.service';
 import { KlaroService } from '../../app/shared/cookies/klaro.service';
@@ -44,6 +45,7 @@ export class BrowserInitService extends InitService {
     protected localeService: LocaleService,
     protected angulartics2DSpace: Angulartics2DSpace,
     protected googleAnalyticsService: GoogleAnalyticsService,
+    protected matomoAnalyticsService: MatomoAnalyticsService,
     protected metadata: MetadataService,
     protected breadcrumbsService: BreadcrumbsService,
     protected klaroService: KlaroService,
@@ -85,6 +87,7 @@ export class BrowserInitService extends InitService {
       this.initI18n();
       this.initAngulartics();
       this.initGoogleAnalytics();
+      this.initMatomoAnalytics();
       this.initRouteListeners();
       this.themeService.listenForThemeChanges(true);
       this.trackAuthTokenExpiration();
@@ -130,5 +133,9 @@ export class BrowserInitService extends InitService {
 
   protected initGoogleAnalytics() {
     this.googleAnalyticsService.addTrackingIdToPage();
+  }
+
+  protected initMatomoAnalytics() {
+    this.matomoAnalyticsService.addTrackingIdToPage();
   }
 }

--- a/src/modules/app/server-app.module.ts
+++ b/src/modules/app/server-app.module.ts
@@ -6,7 +6,7 @@ import { ServerModule, ServerTransferStateModule } from '@angular/platform-serve
 
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
-import { Angulartics2, Angulartics2GoogleAnalytics, Angulartics2GoogleTagManager } from 'angulartics2';
+import { Angulartics2, Angulartics2GoogleAnalytics, Angulartics2GoogleTagManager, Angulartics2Matomo } from 'angulartics2';
 
 import { AppComponent } from '../../app/app.component';
 
@@ -60,6 +60,10 @@ export function createTranslateLoader(transferState: TransferState) {
     },
     {
       provide: Angulartics2GoogleAnalytics,
+      useClass: AngularticsProviderMock
+    },
+    {
+      provide: Angulartics2Matomo,
       useClass: AngularticsProviderMock
     },
     {


### PR DESCRIPTION
Followed the pattern used for Google Analytics to set up similar classes and configuration for Matomo Analytics.

https://umd-dit.atlassian.net/browse/LIBDRUM-808


