### PR TITLE
LIBDRUM-781. Enable URL hyperlink rendering for the "Notes" field

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -26,4 +26,8 @@ bundle:
 # Disable End User Agreement
 info:
   enableEndUserAgreement: false
+
+# Enable Markdown in metadata display
+markdown:
+  enabled: true
 # End UMD Customization

--- a/docs/DrumAngularCustomization.md
+++ b/docs/DrumAngularCustomization.md
@@ -1,0 +1,23 @@
+# DRUM Angular Customizations
+
+## Introduction
+
+This document contains information related to changes made to the stock DSpace
+Angular code, to customize it for DRUM.
+
+This document is intended to cover specific changes made to Angular behavior
+that are outside of "normal" DSpace customization.
+
+## Disable "End User Agreement"
+
+The "End User Agreement" is not needed, and so is disabled in the
+"config/config.yml" file.
+
+## "PRESERVATION" added to standard bundle list
+
+The list of standard bundles has been augmented with a "PRESERVATION" bundle.
+
+## Markdown enabled metadata display
+
+Markdown rendering has been enabled for the "Note" (dc.description) field
+on the simple item page, to enable bare URLs to be rendered as hyperlinks.

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -79,7 +79,8 @@
     <!-- Notes -->
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"
-      [label]="'item.page.description'">
+      [label]="'item.page.description'"
+      [enableMarkdown]="true">
     </ds-generic-item-page-field>
 
     <!-- URI (handle) -->


### PR DESCRIPTION
Enabled Markdown rendering in the "Notes" (dc.description) field on the simple item page so that simple URLs would be rendered as clickable hyperlinks.

Added a "docs/DrumAngularCustomization.md" page to record DRUM-specific Angular customizations.

https://umd-dit.atlassian.net/browse/LIBDRUM-781
