### PR TITLE
LIBDRUM-827. Keep bitstream download count separate from file hyperlink

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5469,6 +5469,8 @@
 
   "admin.registries.metadata.description": "The metadata registry maintains a list of all metadata fields available in the repository. These fields may be divided amongst multiple schemas. However, DRUM requires the qualified Dublin Core schema.",
 
+  "bitstream.download.counter.label": "No. of downloads:",
+
   "bitstream.embargoed.text": "(RESTRICTED ACCESS)",
 
   "bitstream.restricted-access.anonymous.forbidden.message": "The file you are attempting to access is restricted.",

--- a/src/themes/drum/app/item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/themes/drum/app/item-page/simple/field-components/file-section/file-section.component.html
@@ -1,16 +1,23 @@
 <ng-container *ngVar="(bitstreams$ | async) as bitstreams">
   <ds-metadata-field-wrapper *ngIf="bitstreams?.length > 0" [label]="label | translate">
     <div class="file-section">
-      <ds-themed-file-download-link *ngFor="let file of bitstreams; let last=last;" [bitstream]="file" [item]="item">
-        <span>{{ dsoNameService.getName(file) }}</span>
-        <span> ({{(file?.sizeBytes) | dsFileSize }})</span>
-        <span *ngIf="!last" innerHTML="{{separator}}"></span>
-        <!-- UMD Customization -->
+      <!-- UMD Customization -->
+      <!--
+        Using a separate ngFor in an ng-container, instead of using ngFor
+        in ds-themed-file-download-link to give ds-bitstream-download-counter
+        access to the file information.
+      -->
+      <ng-container *ngFor="let file of bitstreams; let last=last;">
+        <ds-themed-file-download-link [bitstream]="file" [item]="item">
+          <span>{{ dsoNameService.getName(file) }}</span>
+          <span> ({{(file?.sizeBytes) | dsFileSize }})</span>
+          <span *ngIf="!last" innerHTML="{{separator}}"></span>
+        </ds-themed-file-download-link>
         <div>
           <ds-bitstream-download-counter [bitstream]="file" label="No. of downloads:"></ds-bitstream-download-counter>
         </div>
-        <!-- End UMD Customization -->
-      </ds-themed-file-download-link>
+      </ng-container>
+      <!-- End UMD Customization -->
       <ds-themed-loading *ngIf="isLoading" message="{{'loading.default' | translate}}" [showMessage]="false"></ds-themed-loading>
       <div *ngIf="!isLastPage" class="mt-1" id="view-more">
         <button class="bitstream-view-more btn btn-outline-secondary btn-sm" (click)="getNextPage()">{{'item.page.bitstreams.view-more' | translate}}</button>

--- a/src/themes/drum/app/item-page/simple/field-components/file-section/file-section.component.html
+++ b/src/themes/drum/app/item-page/simple/field-components/file-section/file-section.component.html
@@ -14,7 +14,7 @@
           <span *ngIf="!last" innerHTML="{{separator}}"></span>
         </ds-themed-file-download-link>
         <div>
-          <ds-bitstream-download-counter [bitstream]="file" label="No. of downloads:"></ds-bitstream-download-counter>
+          <ds-bitstream-download-counter [bitstream]="file" label="{{'bitstream.download.counter.label' | translate}}"></ds-bitstream-download-counter>
         </div>
       </ng-container>
       <!-- End UMD Customization -->


### PR DESCRIPTION
In the DSpace 7.6 upgrade, this file was modified to match the stock
DSpace file in which the "ngFor" iterator was part of the
"ds-themed-file-download-link" component, and the
"ds-bitstream-download-counter" component was part of the
"ds-themed-file-download-link" content. This caused an issue in which
the bitstream download count was included as part of the file hyperlink.

Fixed the issue by moving the "ngFor" iterator into a separate
"ngContainer", and moving the "ds-bitstream-download-counter" component
out of the content of the "ds-themed-file-download-link" component.

Also, moved the "No. of downloads:" text for the label used by the
"ds-bitstream-download-counter" component into the "en.json5" file.

This was done to maintain consistent use of I18n text.

https://umd-dit.atlassian.net/browse/LIBDRUM-827