### PR TITLE
LIBDRUM-842. Restore DRUM logo to navigation bar

### DIFF
--- a/src/themes/drum/app/header/header.component.html
+++ b/src/themes/drum/app/header/header.component.html
@@ -2,16 +2,19 @@
 <ds-umd-header></ds-umd-header>
 <ds-umd-environment-banner></ds-umd-environment-banner>
 <ds-json-ld-website scriptId='json-ld-website'></ds-json-ld-website>
+<!-- End UMD Customization -->
 <header class="header">
   <nav role="navigation" [attr.aria-label]="'nav.user.description' | translate" class="container navbar navbar-expand-md px-0">
     <div class="d-flex flex-grow-1">
-      <a class="navbar-brand my-2" routerLink="/home">
+      <a class="navbar-brand m-2" routerLink="/home">
+        <!-- UMD Customization -->
         <img src="assets/drum/images/drum-logo.svg" [attr.alt]="'menu.header.image.logo' | translate" />
+        <!-- End UMD Customization -->
       </a>
-      </div>
-    <div class="d-flex flex-grow-1 ml-auto justify-content-end align-items-center">
-      <ds-themed-search-navbar class="navbar-search"></ds-themed-search-navbar>
-      <ds-lang-switch></ds-lang-switch>
+    </div>
+    <div class="navbar-buttons d-flex flex-grow-1 ml-auto justify-content-end align-items-center gapx-1">
+      <ds-themed-search-navbar></ds-themed-search-navbar>
+      <ds-themed-lang-switch></ds-themed-lang-switch>
       <ds-context-help-toggle></ds-context-help-toggle>
       <ds-themed-auth-nav-menu></ds-themed-auth-nav-menu>
       <ds-impersonate-navbar></ds-impersonate-navbar>
@@ -27,4 +30,3 @@
   <ds-themed-navbar></ds-themed-navbar>
 
 </header>
-<!-- End UMD Customization -->

--- a/src/themes/drum/app/header/header.component.scss
+++ b/src/themes/drum/app/header/header.component.scss
@@ -15,7 +15,6 @@
 .navbar-toggler .navbar-toggler-icon {
   background-image: none !important;
   line-height: 1.5;
-  color: var(--bs-link-color);
 }
 
 .navbar-toggler {

--- a/src/themes/drum/app/navbar/navbar.component.html
+++ b/src/themes/drum/app/navbar/navbar.component.html
@@ -3,8 +3,8 @@
   <div class="navbar-inner-container w-100 h-100" [class.container]="!(isXsOrSm$ | async)">
     <a class="navbar-brand my-2" routerLink="/home">
       <!-- UMD Customization -->
-      <img src="assets/drum/images/drum-logo.svg" [attr.alt]="'menu.header.image.logo' | translate" />
-      <!-- UMD Customization -->
+      <img style="height: 70px" src="assets/drum/images/drum-logo.svg" [attr.alt]="'menu.header.image.logo' | translate" />
+      <!-- End UMD Customization -->
     </a>
 
     <div id="collapsingNav" class="w-100 h-100">

--- a/src/themes/drum/app/navbar/navbar.component.scss
+++ b/src/themes/drum/app/navbar/navbar.component.scss
@@ -1,43 +1,57 @@
 nav.navbar {
-    background-color: var(--ds-navbar-bg);
-    // UMD Customization
-    border-bottom: 5px #454545 solid;
-    // End UMD Customization
-    align-items: baseline;
+  align-items: baseline;
+
+  .navbar-inner-container {
+    border-top: 1px var(--ds-header-navbar-border-top-color) solid;
+  }
+}
+
+.navbar-nav {
+  background-color: var(--ds-navbar-bg);
 }
 
 /** Mobile menu styling **/
 @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
-    .navbar {
-        width: 100%;
-        background-color: var(--bs-white);
-        position: absolute;
-        overflow: hidden;
-        height: 0;
-        z-index: var(--ds-nav-z-index);
-        &.open {
-          height: auto;
-          min-height: 100vh; //doesn't matter because wrapper is sticky
-          border-bottom: 1px var(--ds-header-navbar-border-bottom-color) solid; // open navbar covers header-navbar-wrapper border
-        }
+  .navbar {
+    width: 100vw;
+    background-color: var(--bs-white);
+    position: absolute;
+    overflow: hidden;
+    height: 0;
+    z-index: var(--ds-nav-z-index);
+    &.open {
+      height: 100vh; //doesn't matter because wrapper is sticky
+      border-bottom: 5px var(--ds-header-navbar-border-bottom-color) solid; // open navbar covers header-navbar-wrapper border
     }
+  }
 }
 
 @media screen and (min-width: map-get($grid-breakpoints, md)) {
-    .reset-padding-md {
-        margin-left: calc(var(--bs-spacer) / -2);
-        margin-right: calc(var(--bs-spacer) / -2);
-    }
+  .reset-padding-md {
+    margin-left: calc(var(--bs-spacer) / -2);
+    margin-right: calc(var(--bs-spacer) / -2);
+  }
 }
 
 /* TODO remove when https://github.com/twbs/bootstrap/issues/24726 is fixed */
 .navbar-expand-md.navbar-container {
-    @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
-        > .navbar-inner-container {
-            padding: 0 var(--bs-spacer);
-        }
-        padding: 0;
+  @media screen and (max-width: map-get($grid-breakpoints, md)-0.02) {
+    > .navbar-inner-container {
+      padding: 0 var(--bs-spacer);
+      a.navbar-brand {
+        display: none;
+      }
+      .navbar-collapsed {
+        display: none;
+      }
     }
+    padding: 0;
+  }
+  height: 80px;
+}
+
+a.navbar-brand img {
+  max-height: var(--ds-header-logo-height);
 }
 
 .navbar-nav {

--- a/src/themes/drum/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/drum/styles/_theme_css_variable_overrides.scss
@@ -8,5 +8,6 @@
   --ds-header-logo-height: 70px;
   --ds-home-news-link-color: #ffd200; // "Maryland Gold", see https://brand.umd.edu/colors
   --ds-home-news-link-hover-color: #ffd200;
+  --ds-header-navbar-border-bottom-color: #454545;
 }
 


### PR DESCRIPTION
Incomplete merging of the DSpace 7.6.1 changes to the navigation bar HTML and SCSS was causing the DRUM logo to not appear in wider screens.

Migrated DSpace 7.6.1 changes in the "src/themes/dspace" theme into the "src/themes/drum" theme.

Also updated the "ds-header-navbar-border-bottom-color" SCSS variable in the "_theme_css_variable_overrides.scss" file to use the DRUM-preferred color.

https://umd-dit.atlassian.net/browse/LIBDRUM-842
