### PR TITLE
LIBDRUM-843. Replace DSpace logo on the /login page with DRUM logo

### DIFF
--- a/docs/DrumAngularCustomization.md
+++ b/docs/DrumAngularCustomization.md
@@ -8,7 +8,7 @@ Angular code, to customize it for DRUM.
 This document is intended to cover specific changes made to Angular behavior
 that are outside of "normal" DSpace customization.
 
-## Disable "End User Agreement"
+## Disabled "End User Agreement"
 
 The "End User Agreement" is not needed, and so is disabled in the
 "config/config.yml" file.
@@ -21,3 +21,8 @@ The list of standard bundles has been augmented with a "PRESERVATION" bundle.
 
 Markdown rendering has been enabled for the "Note" (dc.description) field
 on the simple item page, to enable bare URLs to be rendered as hyperlinks.
+
+## Replaced DSpace logo on login page with DRUM logo
+
+Replaced the DSpace logo on the login page with the DRUM logo to provide
+consistent branding of the application.

--- a/src/themes/drum/app/login-page/login-page.component.html
+++ b/src/themes/drum/app/login-page/login-page.component.html
@@ -1,0 +1,12 @@
+<div class="container w-100 h-100">
+  <div class="text-center mt-5 row justify-content-center">
+    <div>
+      <!-- UMD Customization -->
+      <img class="mb-4 login-logo" src="assets/drum/images/drum-logo.svg">
+      <!-- End UMD Customization -->
+      <h1 class="h3 mb-0 font-weight-normal">{{"login.form.header" | translate}}</h1>
+      <ds-themed-log-in
+      [isStandalonePage]="true"></ds-themed-log-in>
+    </div>
+  </div>
+</div>

--- a/src/themes/drum/app/login-page/login-page.component.scss
+++ b/src/themes/drum/app/login-page/login-page.component.scss
@@ -1,0 +1,4 @@
+.login-logo {
+  height: var(--ds-login-logo-height);
+  width: var(--ds-login-logo-width);
+}

--- a/src/themes/drum/app/login-page/login-page.component.ts
+++ b/src/themes/drum/app/login-page/login-page.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { LoginPageComponent as BaseComponent } from '../../../../app/login-page/login-page.component';
+
+/**
+ * This component represents the login page
+ */
+@Component({
+  selector: 'ds-login-page',
+  styleUrls: ['./login-page.component.scss'],
+  templateUrl: './login-page.component.html'
+})
+export class LoginPageComponent extends BaseComponent {
+}

--- a/src/themes/drum/lazy-theme.module.ts
+++ b/src/themes/drum/lazy-theme.module.ts
@@ -66,11 +66,13 @@ import { EtdUnitsModule } from 'src/app/etdunit-registry/etdunits.module';
 import { ItemPageComponent } from './app/item-page/simple/item-page.component';
 import { JsonLdDatasetComponent } from './app/item-page/json-ld/json-ld-dataset.component';
 import { RestrictedAccessPageModule } from 'src/app/restricted-access/restricted-access-page.module';
+import { LoginPageComponent } from './app/login-page/login-page.component';
 // End UMD Customization
 
 const DECLARATIONS = [
   ItemPageComponent,
   JsonLdDatasetComponent,
+  LoginPageComponent,
   PrivacyComponent,
   UnitsRegistryComponent,
 ];

--- a/src/themes/drum/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/drum/styles/_theme_css_variable_overrides.scss
@@ -9,5 +9,7 @@
   --ds-header-navbar-border-bottom-color: #454545;
   --ds-home-news-link-color: #ffd200; // "Maryland Gold", see https://brand.umd.edu/colors
   --ds-home-news-link-hover-color: #ffd200;
+  --ds-login-logo-height: 70px;
+  --ds-login-logo-width: auto;
 }
 


### PR DESCRIPTION
Added the "login-page" component to the "drum" theme by copying the files from the "custom" theme. Modified the files to replace the DSpace logo on the /login page with the DRUM logo.

Added "--ds-login-logo-height/--ds-login-logo-width" to the "src/themes/drum/styles/_theme_css_variable_overrides.scss" file to set the correct width/height for the DRUM logo on the page.

Updated the "docs/DrumAngularCustomization.md" document.

https://umd-dit.atlassian.net/browse/LIBDRUM-843
