### PR TITLE
LIBDRUM-838. Added "Submit item to DRUM" menu entry to navigation bar

### DIFF
--- a/docs/DrumAngularCustomization.md
+++ b/docs/DrumAngularCustomization.md
@@ -26,3 +26,11 @@ on the simple item page, to enable bare URLs to be rendered as hyperlinks.
 
 Replaced the DSpace logo on the login page with the DRUM logo to provide
 consistent branding of the application.
+
+## Added "Submit item to DRUM" link in navigation bar
+
+To make it more obvious how to submit items to DRUM, added a
+"Submit item to DRUM" menu entry in the navigation bar. This menu entry is only
+displayed for logged-in users that have "submit" permission to at least one
+collection. It is essentially a duplicate of the "New | Item" menu
+entry in the administrative sidebar.

--- a/src/app/menu.resolver.ts
+++ b/src/app/menu.resolver.ts
@@ -143,6 +143,28 @@ export class MenuResolver implements Resolve<boolean> {
         })));
       });
 
+    // UMD Customization
+    // "Submit item to DRUM" entry, matching the 'new_item' entry in the
+    // administrative sidebar
+    this.authorizationService.isAuthorized(FeatureID.CanSubmit)
+    .subscribe((canSubmit) => {
+      this.menuService.addSection(MenuID.PUBLIC, {
+        id: `drum_customizations_submit_item`,
+        active: false,
+        visible: canSubmit,
+        index: 3, // Statistics menu entry is index 2
+        model: {
+          type: MenuItemType.ONCLICK,
+          text: `nav.umd.submit_item.header`,
+          function: () => {
+            this.modalService.open(ThemedCreateItemParentSelectorComponent);
+          }
+        } as OnClickMenuItemModel,
+        shouldPersistOnRouteChange: true
+      });
+    });
+    // End UMD Customization
+
     return this.waitForMenu$(MenuID.PUBLIC);
   }
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5597,6 +5597,8 @@
 
   "nav.mydspace": "My Submissions",
 
+  "nav.umd.submit_item.header": "Submit item to DRUM",
+
   "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to DRUM.",
 
   "repository.title.prefix": "DRUM :: ",


### PR DESCRIPTION
Added a "Submit item to DRUM" menu entry to the navigation bar that displays for logged-in users that have "submit" permission to at least one collection.

This menu entry is essentially a duplicate of the "New | Item" menu entry in the administrative sidebar.

The "index" is set to "3" so that it will show at the end of the navigation bar entries (the index "2" is used by the "Statistics" menu entry).

https://umd-dit.atlassian.net/browse/LIBDRUM-839
