### PR TITLE
LIBDRUM-797. Fix "Show More" button for subcommunities

### DIFF
--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.html
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.html
@@ -8,12 +8,10 @@
         <span class="fa fa-chevron-right invisible" aria-hidden="true"></span>
       </button>
       <div class="align-middle pt-2">
-        <!-- UMD Customization -->
-        <button *ngIf="node!==loadingNode" (click)="getMaxAllowedCommunities(node)"
+        <button *ngIf="!(dataSource.loading$ | async)" (click)="getNextPage(node)"
            class="btn btn-outline-primary btn-sm" role="button">
            <i class="fas fa-angle-down"></i> {{ 'communityList.showMore' | translate }}
         </button>
-        <!-- End UMD Customization -->
         <ds-themed-loading *ngIf="node===loadingNode && dataSource.loading$ | async" class="ds-themed-loading"></ds-themed-loading>
       </div>
     </div>

--- a/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
+++ b/src/themes/drum/app/community-list-page/community-list/community-list.component.ts
@@ -156,28 +156,12 @@ export class CommunityListComponent implements OnInit, OnDestroy {
     } else {
       this.paginationConfig.currentPage++;
       // UMD Customization
+      // When the "Show More" button is clicked in a subcommunoty, retrieve up
+      // to MAX_COMCOLS_PER_PAGE additional entries, instead of the DSpace
+      // default of 5 entries
+      this.paginationConfig.elementsPerPage = MAX_COMCOLS_PER_PAGE;
       this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes, this.communityGroupId);
       // End UMD Customization
     }
   }
-
-  // UMD Customization
-  /**
-  * The method helps show the entire community list (i.e, upto the MAX_COMCOLS_PER_PAGE) instead
-  * of just getting the next page. This is achived by leaving the current page to the initial
-  * value '1' and changing the elementsPerPage to the MAX_COMCOLS_PER_PAGE. The community list
-  * service gets all the pages (from cache when available) up to the current page, therefore
-  * we do not need to worry about deduplicating list. See https://github.com/umd-lib/dspace-angular/blob/b5a2c0ff39c530983a8caf29709a4c24095a774c/src/themes/drum/app/community-list-page/community-list-service.ts#L55-L58
-  *
-  * This method is only used by the "show more" button, i.e for top-level communities only, so we
-  * do not need to handle subCommunities or collections.
-  *
-  */
-  getMaxAllowedCommunities(node: FlatNode): void {
-    this.loadingNode = node;
-    this.paginationConfig.elementsPerPage = MAX_COMCOLS_PER_PAGE;
-    this.dataSource.loadCommunities(this.paginationConfig, this.expandedNodes, this.communityGroupId);
-  }
-  // End UMD Customization
-
 }


### PR DESCRIPTION
In "community-list.component.ts", fixed the "Show More" button when displayed in subcommunities such as the
“MARAC Mid-Atlantic Regional Archives Conference” community by replacing the use of the "getMaxAllowedCommunities" method with the "nextPage" method. The "nextPage" method was modified to retrieve up to "MAX_COMCOLS_PER_PAGE" entries, instead of the DSpace default of 5 entries. The "getMaxAllowedCommunities" method was no longer needed, and so was removed

Replaced the use of "getMaxAllowedCommunities" in the "community-list.component.html" file with "getNextPage". This restores the HTML file to being identical with the stock DSpace version, but retaining the HTML file because this really represents the HTML for the UMD custom "ds-cg-community-list" component, not the stock DSpace "ds-community-list", so the similarity is coincidental, not duplicative.

https://umd-dit.atlassian.net/browse/LIBDRUM-797
