### PR TITLE
LIBDRUM-846. Tweaks to DRUM homepage

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5597,7 +5597,7 @@
 
   "nav.mydspace": "My Submissions",
 
-  "nav.umd.submit_item.header": "Submit item to DRUM",
+  "nav.umd.submit_item.header": "Submit Item to DRUM",
 
   "register-page.registration.info": "Register an account to subscribe to collections for email updates, and submit new items to DRUM.",
 

--- a/src/themes/drum/app/home-page/home-news/home-news.component.html
+++ b/src/themes/drum/app/home-page/home-news/home-news.component.html
@@ -40,8 +40,10 @@
         </a>
       </p>
       <p>
-        To submit an item to DRUM, login using your UMD credentials. Then select
-        the "Submit item to DRUM" link in the navigation bar.
+        <b>
+          To submit an item to DRUM, login using your UMD credentials. Then select
+          the "Submit Item to DRUM" link in the navigation bar.
+        </b>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Implemented the following changes to the DRUM homepage based on a a February 6, 2024 email from Terry Owen:

1) In the banner, capitalize the "I" in Item so it reads
   "Submit Item to DRUM".

2) In the last sentence of the text in the red box, capitalize the I in
   the "Submit Item to DRUM" so the sentence would read:

    > To submit an item to DRUM, login using your UMD credentials.
      Then select the "Submit Item to DRUM" link in the navigation bar.

3) We need the last sentence to stand out, so please BOLD the last sentence:

**To submit an item to DRUM, login using your UMD credentials. Then select the "Submit Item to DRUM" link in the navigation bar.**

https://umd-dit.atlassian.net/browse/LIBDRUM-846
