### PR TITLE
LIBDRUM-876. Added "Submission Type" label for "Type" form section

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -5745,6 +5745,10 @@
 
   "submission.import-external.page.hint": "Enter a query above to find items from the web to import in to DRUM.",
 
+  "submission.sections.submit.progressbar.describe.umdType": "Submission Type",
+
+  "submission.sections.submit.progressbar.describe.mhheaType": "Submission Type",
+
   "submission.sections.submit.progressbar.equitableAccessSubmission": "Equitable Access",
 
   "title": "DRUM",


### PR DESCRIPTION
Added "Submission Type" label to apply to the "umdType" and "mhheaType" steps in the default and MHHEA submission forms.

https://umd-dit.atlassian.net/browse/LIBDRUM-876
