### PR TITLE
LIBDRUM-879. Fixes to dspace-angular tests

### DIFF
--- a/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.spec.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.spec.ts
@@ -10,6 +10,12 @@ import { AdminSidebarSectionComponent } from './admin-sidebar-section.component'
 import { RouterTestingModule } from '@angular/router/testing';
 import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
+// UMD Customization
+// Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+// This customization should be removed when upgrading to DSpace 8.0 or later
+import { NativeWindowService } from 'src/app/core/services/window.service';
+import { NativeWindowMockFactory } from 'src/app/shared/mocks/mock-native-window-ref';
+// End UMD Customization
 
 describe('AdminSidebarSectionComponent', () => {
   let component: AdminSidebarSectionComponent;
@@ -27,6 +33,11 @@ describe('AdminSidebarSectionComponent', () => {
           {provide: 'sectionDataProvider', useValue: {model: {link: 'google.com'}, icon: iconString}},
           {provide: MenuService, useValue: menuService},
           {provide: CSSVariableService, useClass: CSSVariableServiceStub},
+          // UMD Customization
+          // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+          // This customization should be removed when upgrading to DSpace 8.0 or later
+          { provide: NativeWindowService, useFactory: NativeWindowMockFactory },
+          // End UMD Customization
         ]
       }).overrideComponent(AdminSidebarSectionComponent, {
         set: {
@@ -67,6 +78,11 @@ describe('AdminSidebarSectionComponent', () => {
           {provide: 'sectionDataProvider', useValue: {model: {link: 'google.com', disabled: true}, icon: iconString}},
           {provide: MenuService, useValue: menuService},
           {provide: CSSVariableService, useClass: CSSVariableServiceStub},
+          // UMD Customization
+          // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+          // This customization should be removed when upgrading to DSpace 8.0 or later
+          { provide: NativeWindowService, useFactory: NativeWindowMockFactory },
+          // End UMD Customization
         ]
       }).overrideComponent(AdminSidebarSectionComponent, {
         set: {

--- a/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar-section/admin-sidebar-section.component.ts
@@ -1,7 +1,6 @@
 // UMD Customization
 // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
 // This customization should be removed when upgrading to DSpace 8.0 or later
-import { NgClass } from '@angular/common';
 import { BehaviorSubject } from 'rxjs';
 import { NativeWindowRef, NativeWindowService } from '../../../core/services/window.service';
 // End UMD Customization

--- a/src/app/admin/admin-sidebar/admin-sidebar.component.spec.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.spec.ts
@@ -21,6 +21,12 @@ import { createSuccessfulRemoteDataObject } from '../../shared/remote-data.utils
 import { Item } from '../../core/shared/item.model';
 import { ThemeService } from '../../shared/theme-support/theme.service';
 import { getMockThemeService } from '../../shared/mocks/theme-service.mock';
+// UMD Customization
+// Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+// This customization should be removed when upgrading to DSpace 8.0 or later
+import { NativeWindowService } from 'src/app/core/services/window.service';
+import { NativeWindowMockFactory } from 'src/app/shared/mocks/mock-native-window-ref';
+// End UMD Customization
 
 describe('AdminSidebarComponent', () => {
   let comp: AdminSidebarComponent;
@@ -69,6 +75,11 @@ describe('AdminSidebarComponent', () => {
         { provide: AuthorizationDataService, useValue: authorizationService },
         { provide: ScriptDataService, useValue: scriptService },
         { provide: ActivatedRoute, useValue: routeStub },
+        // UMD Customization
+        // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+        // This customization should be removed when upgrading to DSpace 8.0 or later
+        { provide: NativeWindowService, useFactory: NativeWindowMockFactory },
+        // End UMD Customization
         {
           provide: NgbModal, useValue: {
             open: () => {/*comment*/

--- a/src/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/src/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -1,8 +1,7 @@
 // UMD Customization
 // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
 // This customization should be removed when upgrading to DSpace 8.0 or later
-import { NgClass } from '@angular/common';
-import { Inject } from'@angular/core';
+import { Inject } from '@angular/core';
 import { NativeWindowRef, NativeWindowService } from '../../core/services/window.service';
 // End UMD Customization
 import { Component, HostListener, Injector, Input, OnInit } from '@angular/core';

--- a/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.spec.ts
+++ b/src/app/admin/admin-sidebar/expandable-admin-sidebar-section/expandable-admin-sidebar-section.component.spec.ts
@@ -12,6 +12,12 @@ import { By } from '@angular/platform-browser';
 import { TranslateModule } from '@ngx-translate/core';
 import { Router } from '@angular/router';
 import { RouterStub } from '../../../shared/testing/router.stub';
+// UMD Customization
+// Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+// This customization should be removed when upgrading to DSpace 8.0 or later
+import { NativeWindowService } from 'src/app/core/services/window.service';
+import { NativeWindowMockFactory } from 'src/app/shared/mocks/mock-native-window-ref';
+// End UMD Customization
 
 describe('ExpandableAdminSidebarSectionComponent', () => {
   let component: ExpandableAdminSidebarSectionComponent;
@@ -27,6 +33,11 @@ describe('ExpandableAdminSidebarSectionComponent', () => {
         { provide: MenuService, useValue: menuService },
         { provide: CSSVariableService, useClass: CSSVariableServiceStub },
         { provide: Router, useValue: new RouterStub() },
+        // UMD Customization
+        // Adaption of DSpace 8.0 fix from https://github.com/DSpace/dspace-angular/pull/2976
+        // This customization should be removed when upgrading to DSpace 8.0 or later
+        { provide: NativeWindowService, useFactory: NativeWindowMockFactory },
+        // End UMD Customization
       ]
     }).overrideComponent(ExpandableAdminSidebarSectionComponent, {
       set: {

--- a/src/app/home-page/recent-item-list/recent-item-list.component.html
+++ b/src/app/home-page/recent-item-list/recent-item-list.component.html
@@ -2,7 +2,7 @@
         <!-- UMD Customization -->
         <div class="mt-4 mt-sm-0" [ngClass]="placeholderFontClass" *ngIf="itemRD?.hasSucceeded && itemRD?.payload?.page.length > 0" @fadeIn>
                 <div class="d-xs-block d-sm-none d-flex flex-row border-bottom mb-4 pb-4"></div>
-        <!-- End UMD Customizaton -->
+        <!-- End UMD Customization -->
                 <h2> {{'home.recent-submissions.head' | translate}}</h2>
                 <div class="my-4" *ngFor="let item of itemRD?.payload?.page">
                         <ds-listable-object-component-loader [object]="item" [viewMode]="viewMode" class="pb-4">

--- a/src/themes/drum/styles/_global-styles.scss
+++ b/src/themes/drum/styles/_global-styles.scss
@@ -8,6 +8,17 @@
   --umd-ds-umd-campus-banner-height: 44px;
 }
 
+// LIBDRUM-879 - Place the z-index of UMD banner below that of the modal
+// dialogs. This enables modal dialogs to overlap the UMD banner, if necessary,
+// instead of being obscured by it. This also ensures that Cypress end-to-end
+// tests that check accessibility will pass successfully.
+//
+// Need the full "body div.umdheader-wrap" selector to override the
+// "umdheader-wrap" selector provided with the UMD banner
+body div.umdheader-wrap {
+  z-index: ($zindex-modal - 100) !important;
+}
+
 // LIBDRUM-694 - Add "margin-top" to notifications-wrapper defined in
 // src/app/shared/notifications/notifications-board/notifications-board.component.scss
 // in order to push notifications appearing in the upper-right corner of the


### PR DESCRIPTION
## Added "NativeWindowService" for sidebar class constructors

In LIBDRUM-872, the sidebar classes were modified to include a
"NativeWindowService" parameter in their constructors, so that the
browser and operating system could be determined. It was overlooked in
that issue that the unit tests also needed to be updated.

Modified the unit tests to include a mock NativeWindowService instance
as the "NativeWindowService" parameter provided to the class
constructors.

https://umd-dit.atlassian.net/browse/LIBDRUM-879