### PR TITLE
LIBDRUM-873. Enable text wrapping in navigation bar entries

### DIFF
--- a/src/themes/drum/app/header/header.component.html
+++ b/src/themes/drum/app/header/header.component.html
@@ -4,24 +4,33 @@
 <ds-json-ld-website scriptId='json-ld-website'></ds-json-ld-website>
 <!-- End UMD Customization -->
 <header id="main-site-header">
-  <div class="container h-100 d-flex flex-row flex-wrap align-items-center justify-content-between gapx-3 gapy-2" id="main-site-header-container">
+  <!-- UMD Customization -->
+  <!-- Change from dspace-angular Pull 3513 -->
+  <div class="container h-100 d-flex flex-row align-items-center justify-content-between gapx-3 gapy-2" id="main-site-header-container">
     <!-- Logo and navbar wrapper -->
     <div id="header-left"
          [attr.role]="(isMobile$ | async) ? 'navigation' : 'presentation'"
          [attr.aria-label]="(isMobile$ | async) ? ('nav.main.description' | translate) : null"
-         class="h-100 flex-fill d-flex flex-row flex-nowrap justify-content-start align-items-center gapx-3">
+         class="h-100 flex-fill d-flex flex-row flex-nowrap justify-content-start align-items-center gapx-3 flex-grow-1">
+  <!-- End UMD Customization -->
       <a class="d-block my-2 my-md-0" routerLink="/home" [attr.aria-label]="'home.title' | translate">
         <!-- UMD Customization -->
         <img id="header-logo" src="assets/drum/images/drum-logo.svg" [attr.alt]="'menu.header.image.logo' | translate" />
         <!-- End UMD Customization -->
 
       </a>
-      <nav *ngIf="!(isMobile$ | async)" class="navbar navbar-expand p-0 align-items-stretch align-self-stretch" id="desktop-navbar" [attr.aria-label]="'nav.main.description' | translate">
+      <!-- UMD Customization -->
+      <!-- Change from dspace-angular Pull 3513 -->
+      <nav *ngIf="!(isMobile$ | async)" class="navbar navbar-expand p-0 align-items-stretch align-self-stretch flex-grow-1 flex-shrink-1" id="desktop-navbar" [attr.aria-label]="'nav.main.description' | translate">
         <ds-themed-navbar></ds-themed-navbar>
       </nav>
+      <!-- End UMD Customization -->
     </div>
     <!-- Search bar and other menus -->
-    <div id="header-right" class="h-100 d-flex flex-row flex-nowrap justify-content-end align-items-center gapx-1 ml-auto">
+    <!-- UMD Customization -->
+    <!-- Change from dspace-angular Pull 3513 -->
+    <div id="header-right" class="h-100 d-flex flex-row flex-nowrap flex-shrink-0 justify-content-end align-items-center gapx-1 ml-auto">
+    <!-- End UMD Customization -->
       <ds-themed-search-navbar></ds-themed-search-navbar>
       <div role="menubar" class="h-100 d-flex flex-row flex-nowrap align-items-center gapx-1">
         <ds-themed-lang-switch></ds-themed-lang-switch>

--- a/src/themes/drum/app/header/header.component.html
+++ b/src/themes/drum/app/header/header.component.html
@@ -4,10 +4,7 @@
 <ds-json-ld-website scriptId='json-ld-website'></ds-json-ld-website>
 <!-- End UMD Customization -->
 <header id="main-site-header">
-  <!-- UMD Customization -->
-  <!-- Setting to "flex-nowrap" as otherwise "header-right" div gets lost behind image at smaller browser widths -->
-  <div class="container h-100 d-flex flex-row flex-nowrap align-items-center justify-content-between gapx-3 gapy-2" id="main-site-header-container">
-  <!-- End UMD Customization -->
+  <div class="container h-100 d-flex flex-row flex-wrap align-items-center justify-content-between gapx-3 gapy-2" id="main-site-header-container">
     <!-- Logo and navbar wrapper -->
     <div id="header-left"
          [attr.role]="(isMobile$ | async) ? 'navigation' : 'presentation'"

--- a/src/themes/dspace/app/header-nav-wrapper/header-navbar-wrapper.component.scss
+++ b/src/themes/dspace/app/header-nav-wrapper/header-navbar-wrapper.component.scss
@@ -28,7 +28,10 @@
 
   ::ng-deep {
     .ds-menu-item, .ds-menu-toggler-wrapper {
-      white-space: nowrap;
+      // UMD Customization
+      // Change from dspace-angular Pull 3513
+      //white-space: nowrap;
+      // End UMD Customzation
       text-decoration: none;
     }
 

--- a/src/themes/dspace/app/navbar/navbar.component.html
+++ b/src/themes/dspace/app/navbar/navbar.component.html
@@ -1,7 +1,10 @@
 <ng-container *ngIf="(isMobile$ | async) && (isAuthenticated$ | async)">
   <ds-user-menu [inExpandableNavbar]="true"></ds-user-menu>
 </ng-container>
-<div class="navbar-nav h-100 align-items-md-stretch gapx-3" role="menubar" id="main-site-navigation" [ngClass]="(isMobile$ | async) ? 'navbar-nav-mobile' : 'navbar-nav-desktop'">
+<!-- UMD Customization -->
+<!-- Change from dspace-angular Pull 3513 -->
+<div class="navbar-nav flex-shrink-1 h-100 align-items-md-stretch gapx-3" role="menubar" id="main-site-navigation" [ngClass]="(isMobile$ | async) ? 'navbar-nav-mobile' : 'navbar-nav-desktop'">
+<!-- End UMD Customization -->
   <ng-container *ngFor="let section of (sections | async)">
     <ng-container
       *ngComponentOutlet="(sectionMap$ | async).get(section.id)?.component; injector: (sectionMap$ | async).get(section.id)?.injector;"></ng-container>


### PR DESCRIPTION
Incorporates the changes from dspace-angular Pull Request
3513, into the appropriate "drum" and "dspace" theme files.

The changes in Pull Request 3513 enable the entries in the navigation
bar to perform text wrapping at smaller browser widths (similar to the
behavior in DSpace 7.6.1) so that the right-most navigation bar entries
are available at nearly all browser widths.

There are still some browser widths at which the right-most entry is
fully obscured, but this same behavior was also seen in DSpace 7.6.1.

https://umd-dit.atlassian.net/browse/LIBDRUM-873