### PR TITLE
LIBDRUM-870. Suppress display of license bundle on full item page

### DIFF
--- a/docs/DrumAngularCustomization.md
+++ b/docs/DrumAngularCustomization.md
@@ -37,5 +37,24 @@ entry in the administrative sidebar.
 
 ## Uncommented "/browse/*" endpoints in "robots.txt"
 
-In the "src/robots.txt.ejs" file, uncommented the "/browse/*" endpoints, to dissuade
-crawlers from those URLs.
+In the "src/robots.txt.ejs" file, uncommented the "/browse/*" endpoints, to
+dissuade crawlers from those URLs.
+
+## Suppress display of "License bundle" files on full item pages
+
+By default in DSpace the full detail page for an item contains a
+"License bundle" section displaying the license file and enabling it to be
+downloaded.
+
+While the majority of the license files are simply the standard DRUM license,
+users have the ability to upload their own license files, which may contain
+personal information such as email addresses.
+
+In DSpace 6, the license file was not downloadable, and we are continuing that
+policy in DSpace 7, to avoid potentially exposing user-specific information.
+
+Note: It does not seem possible in DSpace to restrict the download of files in
+the "License bundle", as it is in the "Original bundle", so if a user knows the
+specific URL of the license file, they will still be able to download it. This
+is currently no particular concern about this, as the the URLs of the license
+files contain UUID-like opaque identifiers that are unlikely to be guessable.

--- a/src/app/item-page/full/field-components/file-section/full-file-section.component.spec.ts
+++ b/src/app/item-page/full/field-components/file-section/full-file-section.component.spec.ts
@@ -88,7 +88,10 @@ describe('FullFileSectionComponent', () => {
   describe('when the full file section gets loaded with bitstreams available', () => {
     it('should contain a list with bitstreams', () => {
       const fileSection = fixture.debugElement.queryAll(By.css('.file-section'));
-      expect(fileSection.length).toEqual(6);
+      // UMD Customization
+      // "License bundle" files should not be present
+      expect(fileSection.length).toEqual(3);
+      // End UMD Customization
     });
   });
 });

--- a/src/app/item-page/full/field-components/file-section/full-file-section.component.ts
+++ b/src/app/item-page/full/field-components/file-section/full-file-section.component.ts
@@ -82,23 +82,26 @@ export class FullFileSectionComponent extends FileSectionComponent implements On
       )
     );
 
-    this.licenses$ = this.paginationService.getCurrentPagination(this.licenseOptions.id, this.licenseOptions).pipe(
-      switchMap((options: PaginationComponentOptions) => this.bitstreamDataService.findAllByItemAndBundleName(
-        this.item,
-        'LICENSE',
-        {elementsPerPage: options.pageSize, currentPage: options.currentPage},
-        true,
-        true,
-        followLink('format'),
-        followLink('thumbnail'),
-      )),
-      tap((rd: RemoteData<PaginatedList<Bitstream>>) => {
-          if (hasValue(rd.errorMessage)) {
-            this.notificationsService.error(this.translateService.get('file-section.error.header'), `${rd.statusCode} ${rd.errorMessage}`);
-          }
-        }
-      )
-    );
+    // UMD Customization
+    // Suppress display of license bundles
+    // this.licenses$ = this.paginationService.getCurrentPagination(this.licenseOptions.id, this.licenseOptions).pipe(
+    //   switchMap((options: PaginationComponentOptions) => this.bitstreamDataService.findAllByItemAndBundleName(
+    //     this.item,
+    //     'LICENSE',
+    //     {elementsPerPage: options.pageSize, currentPage: options.currentPage},
+    //     true,
+    //     true,
+    //     followLink('format'),
+    //     followLink('thumbnail'),
+    //   )),
+    //   tap((rd: RemoteData<PaginatedList<Bitstream>>) => {
+    //       if (hasValue(rd.errorMessage)) {
+    //         this.notificationsService.error(this.translateService.get('file-section.error.header'), `${rd.statusCode} ${rd.errorMessage}`);
+    //       }
+    //     }
+    //   )
+    // );
+    // End UMD Customization
 
   }
 


### PR DESCRIPTION
DRUM provides the ability for users to upload their own licenses which may contain user-specific information such as a user’s email address.

In DSpace 6, the license file was not downloadable, and we wish to continue that policy in DSpace 7, to avoid potentially exposing user-specific information.

From discussions with Terry Owen, removing the “License bundle” section entirely for all users (including Administrators) is acceptable. Administrators will still have access to the files via the “Bitstreams” tab on the “Edit Item” page (with access to that page controlled by DSpace’s access control mechanisms).

DSpace does not seem to provide bitstream-specific access controls to files in the “License bundle”, so if a user were to somehow obtain the URL to the license file, they would still be able to download it. We are not particularly worried about this scenario, as the URLs use opaque UUID-like identifiers that are likely not guessable, so attempting to prevent this is not part of this issue.

Modified the
“src/app/item-page/full/field-components/file-section/full-file-section.component.ts” file directly to simply suppress the retrieval of the license bundle from the back-end, instead of moving the files into the “drum” theme and modifying there, because it seemed more straight-forward, and it would likely simplify future upgrades.

Also modified the
“src/app/item-page/full/field-components/file-section/full-file-section.component.spec.ts” test to account for the license bundle files no longer being downloaded.

Updated the “docs/DrumAngularCustomization.md” document.

https://umd-dit.atlassian.net/browse/LIBDRUM-870
