### PR TITLE
LIBDRUM-899. Updated UMD components to use DSONameService

### DIFF
--- a/src/app/access-control/unit-registry/unit-form/unit-form.component.ts
+++ b/src/app/access-control/unit-registry/unit-form/unit-form.component.ts
@@ -42,6 +42,7 @@ import {
   switchMap,
   take,
 } from 'rxjs/operators';
+import { DSONameService } from 'src/app/core/breadcrumbs/dso-name.service';
 import { AuthorizationDataService } from 'src/app/core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from 'src/app/core/data/feature-authorization/feature-id';
 import { PaginatedList } from 'src/app/core/data/paginated-list.model';
@@ -168,7 +169,9 @@ export class UnitFormComponent implements OnInit, OnDestroy {
     private authorizationService: AuthorizationDataService,
     private modalService: NgbModal,
     public requestService: RequestService,
-    protected changeDetectorRef: ChangeDetectorRef) {
+    protected changeDetectorRef: ChangeDetectorRef,
+    public dsoNameService: DSONameService,
+  ) {
   }
 
   ngOnInit() {
@@ -324,7 +327,7 @@ export class UnitFormComponent implements OnInit, OnDestroy {
       .subscribe((list: PaginatedList<Unit>) => {
         if (list.totalElements > 0) {
           this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.' + notificationSection + '.failure.unitNameInUse', {
-            name: unit.name,
+            name: this.dsoNameService.getName(unit),
           }));
         }
       }));
@@ -357,10 +360,10 @@ export class UnitFormComponent implements OnInit, OnDestroy {
       getFirstCompletedRemoteData(),
     ).subscribe((rd: RemoteData<Unit>) => {
       if (rd.hasSucceeded) {
-        this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.edited.success', { name: rd.payload.name }));
+        this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.edited.success', { name: this.dsoNameService.getName(rd.payload) }));
         this.submitForm.emit(rd.payload);
       } else {
-        this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.edited.failure', { name: unit.name }));
+        this.notificationsService.error(this.translateService.get(this.messagePrefix + '.notification.edited.failure', { name: this.dsoNameService.getName(unit) }));
         this.cancelForm.emit();
       }
     });
@@ -407,7 +410,7 @@ export class UnitFormComponent implements OnInit, OnDestroy {
   delete() {
     this.unitDataService.getActiveUnit().pipe(take(1)).subscribe((unit: Unit) => {
       const modalRef = this.modalService.open(ConfirmationModalComponent);
-      modalRef.componentInstance.dso = unit;
+      modalRef.componentInstance.name = this.dsoNameService.getName(unit);
       modalRef.componentInstance.headerLabel = this.messagePrefix + '.delete-unit.modal.header';
       modalRef.componentInstance.infoLabel = this.messagePrefix + '.delete-unit.modal.info';
       modalRef.componentInstance.cancelLabel = this.messagePrefix + '.delete-unit.modal.cancel';
@@ -420,11 +423,11 @@ export class UnitFormComponent implements OnInit, OnDestroy {
             this.unitDataService.delete(unit.id).pipe(getFirstCompletedRemoteData())
               .subscribe((rd: RemoteData<NoContent>) => {
                 if (rd.hasSucceeded) {
-                  this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.deleted.success', { name: unit.name }));
+                  this.notificationsService.success(this.translateService.get(this.messagePrefix + '.notification.deleted.success', { name: this.dsoNameService.getName(unit) }));
                   this.onCancel();
                 } else {
                   this.notificationsService.error(
-                    this.translateService.get(this.messagePrefix + '.notification.deleted.failure.title', { name: unit.name }),
+                    this.translateService.get(this.messagePrefix + '.notification.deleted.failure.title', { name: this.dsoNameService.getName(unit) }),
                     this.translateService.get(this.messagePrefix + '.notification.deleted.failure.content', { cause: rd.errorMessage }));
                 }
               });

--- a/src/app/access-control/unit-registry/units-registry.component.ts
+++ b/src/app/access-control/unit-registry/units-registry.component.ts
@@ -33,6 +33,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
+import { DSONameService } from 'src/app/core/breadcrumbs/dso-name.service';
 import { AuthorizationDataService } from 'src/app/core/data/feature-authorization/authorization-data.service';
 import { FeatureID } from 'src/app/core/data/feature-authorization/feature-id';
 import {
@@ -124,7 +125,9 @@ export class UnitsRegistryComponent implements OnInit, OnDestroy {
               private notificationsService: NotificationsService,
               private formBuilder: FormBuilder,
               private authorizationService: AuthorizationDataService,
-              private paginationService: PaginationService) {
+              private paginationService: PaginationService,
+              public dsoNameService: DSONameService,
+  ) {
     this.currentSearchQuery = '';
     this.searchForm = this.formBuilder.group(({
       query: this.currentSearchQuery,
@@ -223,10 +226,10 @@ export class UnitsRegistryComponent implements OnInit, OnDestroy {
         .subscribe((rd: RemoteData<NoContent>) => {
           if (rd.hasSucceeded) {
             this.deletedUnitsIds = [...this.deletedUnitsIds, unit.unit.id];
-            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: unit.unit.name }));
+            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(unit.unit) }));
           } else {
             this.notificationsService.error(
-              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: unit.unit.name }),
+              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: this.dsoNameService.getName(unit.unit) }),
               this.translateService.get(this.messagePrefix + 'notification.deleted.failure.content', { cause: rd.errorMessage }));
           }
         });

--- a/src/app/etdunit-registry/etdunits-registry.component.ts
+++ b/src/app/etdunit-registry/etdunits-registry.component.ts
@@ -56,6 +56,7 @@ import { NotificationsService } from 'src/app/shared/notifications/notifications
 import { PaginationComponentOptions } from 'src/app/shared/pagination/pagination-component-options.model';
 import { followLink } from 'src/app/shared/utils/follow-link-config.model';
 
+import { DSONameService } from '../core/breadcrumbs/dso-name.service';
 import { ThemedLoadingComponent } from '../shared/loading/themed-loading.component';
 import { PaginationComponent } from '../shared/pagination/pagination.component';
 import { EtdUnitDataService } from './etdunit-data.service';
@@ -126,7 +127,9 @@ export class EtdUnitsRegistryComponent implements OnInit, OnDestroy {
     private notificationsService: NotificationsService,
     private formBuilder: FormBuilder,
     private authorizationService: AuthorizationDataService,
-    private paginationService: PaginationService) {
+    private paginationService: PaginationService,
+    public dsoNameService: DSONameService,
+  ) {
     this.currentSearchQuery = '';
     this.searchForm = this.formBuilder.group(({
       query: this.currentSearchQuery,
@@ -225,10 +228,10 @@ export class EtdUnitsRegistryComponent implements OnInit, OnDestroy {
         .subscribe((rd: RemoteData<NoContent>) => {
           if (rd.hasSucceeded) {
             this.deletedEtdUnitsIds = [...this.deletedEtdUnitsIds, etdunit.etdunit.id];
-            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: etdunit.etdunit.name }));
+            this.notificationsService.success(this.translateService.get(this.messagePrefix + 'notification.deleted.success', { name: this.dsoNameService.getName(etdunit.etdunit) }));
           } else {
             this.notificationsService.error(
-              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: etdunit.etdunit.name }),
+              this.translateService.get(this.messagePrefix + 'notification.deleted.failure.title', { name: this.dsoNameService.getName(etdunit.etdunit) }),
               this.translateService.get(this.messagePrefix + 'notification.deleted.failure.content', { cause: rd.errorMessage }));
           }
         });


### PR DESCRIPTION
Updated the following components to use the DSONameService when displaying the name of the component instance, following the examples in the stock DSpace classes:

* src/app/access-control/unit-registry/units-registry.component.ts
* src/app/access-control/unit-registry/unit-form/unit-form.component.ts
* src/app/etdunit-registry/etdunits-registry.component.ts

https://umd-dit.atlassian.net/browse/LIBDRUM-899
