### PR TITLE
LIBDRUM-904. Fix display of System-wide Alert banner

### DIFF
--- a/src/app/core/provide-core.ts
+++ b/src/app/core/provide-core.ts
@@ -20,6 +20,13 @@ import { AccessStatusObject } from '../shared/object-collection/shared/badges/ac
 import { IdentifierData } from '../shared/object-list/identifier-data/identifier-data.model';
 import { Subscription } from '../shared/subscriptions/models/subscription.model';
 import { SubmissionCoarNotifyConfig } from '../submission/sections/section-coar-notify/submission-coar-notify.config';
+// UMD Customization
+// Backports DSpace fix to System-wide Alert banner
+// See https://github.com/DSpace/dspace-angular/pull/3671
+// This customization marker should be removed after upgrading to a
+// DSpace version that contains the change.
+import { SystemWideAlert } from '../system-wide-alert/system-wide-alert.model';
+// End UMD Customization
 import { AuthStatus } from './auth/models/auth-status.model';
 import { ShortLivedToken } from './auth/models/short-lived-token.model';
 import { BulkAccessConditionOptions } from './config/models/bulk-access-condition-options.model';
@@ -195,6 +202,13 @@ export const models =
     Itemfilter,
     SubmissionCoarNotifyConfig,
     NotifyRequestsStatus,
+    // UMD Customization
+    // Backports DSpace fix to System-wide Alert banner
+    // See https://github.com/DSpace/dspace-angular/pull/3671
+    // This customization marker should be removed after upgrading to a
+    // DSpace version that contains the change.
+    SystemWideAlert,
+    // Emd UMD Customization
     // UMD Customization
     CommunityGroup,
     Ldap,


### PR DESCRIPTION
Incorporated the changes in DSpace Pull Request 3671 to fix the display of the System-wide Alert banner.

The "UMD Customization" markers added in this commit can be removed once DRUM is upgraded to a DSpace version incorporating the change.

https://umd-dit.atlassian.net/browse/LIBDRUM-904
