### PR TITLE
LIBDRUM-943. Back-port of DSpace 7.6.3 "ssrBaseUrl" functionality

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,7 +1,7 @@
 # NOTE: will log all redux actions and transfers in console
 debug: false
 
-# Angular Universal server settings
+# Angular User Inteface settings
 # NOTE: these settings define where Node.js will start your UI application. Therefore, these
 # "ui" settings usually specify a localhost port/URL which is later proxied to a public URL (using Apache or similar)
 ui:
@@ -17,12 +17,37 @@ ui:
   # Trust X-FORWARDED-* headers from proxies (default = true)
   useProxies: true
 
-universal:
-  # Whether to inline "critical" styles into the server-side rendered HTML.
-  # Determining which styles are critical is a relatively expensive operation;
-  # this option can be disabled to boost server performance at the expense of
-  # loading smoothness.
-  inlineCriticalCss: true
+# Angular Server Side Rendering (SSR) settings
+ssr:
+  # Enable request performance profiling data collection and printing the results in the server console.
+  # Defaults to false. Enabling in production is NOT recommended
+  enablePerformanceProfiler: false
+  # Whether to tell Angular to inline "critical" styles into the server-side rendered HTML.
+  # Determining which styles are critical is a relatively expensive operation; this option is
+  # disabled (false) by default to boost server performance at the expense of loading smoothness.
+  inlineCriticalCss: false
+  # Path prefixes to enable SSR for. By default these are limited to paths of primary DSpace objects.
+  # NOTE: The "/handle/" path ensures Handle redirects work via SSR.  The "/reload/" path ensures
+  # hard refreshes (e.g. after login) trigger SSR while fully reloading the page.
+  paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ]
+  # Whether to enable rendering of Search component on SSR.
+  # If set to true the component will be included in the HTML returned from the server side rendering.
+  # If set to false the component will not be included in the HTML returned from the server side rendering.
+  enableSearchComponent: false
+  # Whether to enable rendering of Browse component on SSR.
+  # If set to true the component will be included in the HTML returned from the server side rendering.
+  # If set to false the component will not be included in the HTML returned from the server side rendering.
+  enableBrowseComponent: false
+  # Enable state transfer from the server-side application to the client-side application.
+  # Defaults to true.
+  # Note: When using an external application cache layer, it's recommended not to transfer the state to avoid caching it.
+  # Disabling it ensures that dynamic state information is not inadvertently cached, which can improve security and
+  # ensure that users always use the most up-to-date state.
+  transferState: true
+  # When a different REST base URL is used for the server-side application, the generated state contains references to
+  # REST resources with the internal URL configured. By default, these internal URLs are replaced with public URLs.
+  # Disable this setting to avoid URL replacement during SSR. In this the state is not transferred to avoid security issues.
+  replaceRestUrl: true
 
 # The REST API server settings
 # NOTE: these settings define which (publicly available) REST API to use. They are usually
@@ -33,6 +58,9 @@ rest:
   port: 443
   # NOTE: Space is capitalized because 'namespace' is a reserved string in TypeScript
   nameSpace: /server
+  # Provide a different REST url to be used during SSR execution. It must contain the whole url including protocol, server port and
+  # server namespace (uncomment to use it).
+  #ssrBaseUrl: http://localhost:8080/server
 
 # Caching settings
 cache:

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -54,6 +54,7 @@ import {
 } from './app-routes';
 import { BROWSE_BY_DECORATOR_MAP } from './browse-by/browse-by-switcher/browse-by-decorator';
 import { AuthInterceptor } from './core/auth/auth.interceptor';
+import { DspaceRestInterceptor } from './core/dspace-rest/dspace-rest.interceptor';
 import { LocaleInterceptor } from './core/locale/locale.interceptor';
 import { LogInterceptor } from './core/log/log.interceptor';
 import {
@@ -146,6 +147,11 @@ export const commonAppConfig: ApplicationConfig = {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: LogInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: DspaceRestInterceptor,
       multi: true,
     },
     // register the dynamic matcher used by form. MUST be provided by the app module

--- a/src/app/core/dspace-rest/dspace-rest.interceptor.spec.ts
+++ b/src/app/core/dspace-rest/dspace-rest.interceptor.spec.ts
@@ -1,0 +1,194 @@
+import {
+  HTTP_INTERCEPTORS,
+  HttpClient,
+} from '@angular/common/http';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../config/app-config.interface';
+import { DspaceRestInterceptor } from './dspace-rest.interceptor';
+import { DspaceRestService } from './dspace-rest.service';
+
+describe('DspaceRestInterceptor', () => {
+  let httpMock: HttpTestingController;
+  let httpClient: HttpClient;
+  const appConfig: Partial<AppConfig> = {
+    rest: {
+      ssl: false,
+      host: 'localhost',
+      port: 8080,
+      nameSpace: '/server',
+      baseUrl: 'http://api.example.com/server',
+    },
+  };
+  const appConfigWithSSR: Partial<AppConfig> = {
+    rest: {
+      ssl: false,
+      host: 'localhost',
+      port: 8080,
+      nameSpace: '/server',
+      baseUrl: 'http://api.example.com/server',
+      ssrBaseUrl: 'http://ssr.example.com/server',
+    },
+  };
+
+  describe('When SSR base URL is not set ', () => {
+    describe('and it\'s in the browser', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfig },
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not modify the request', () => {
+        const url = 'http://api.example.com/server/items';
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+
+    describe('and it\'s in SSR mode', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfig },
+            { provide: PLATFORM_ID, useValue: 'server' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not replace the base URL', () => {
+        const url = 'http://api.example.com/server/items';
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+  });
+
+  describe('When SSR base URL is set ', () => {
+    describe('and it\'s in the browser', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfigWithSSR },
+            { provide: PLATFORM_ID, useValue: 'browser' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should not modify the request', () => {
+        const url = 'http://api.example.com/server/items';
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(url);
+        expect(req.request.url).toBe(url);
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+
+    describe('and it\'s in SSR mode', () => {
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          imports: [HttpClientTestingModule],
+          providers: [
+            DspaceRestService,
+            {
+              provide: HTTP_INTERCEPTORS,
+              useClass: DspaceRestInterceptor,
+              multi: true,
+            },
+            { provide: APP_CONFIG, useValue: appConfigWithSSR },
+            { provide: PLATFORM_ID, useValue: 'server' },
+          ],
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+      });
+
+      it('should replace the base URL', () => {
+        const url = 'http://api.example.com/server/items';
+        const ssrBaseUrl = appConfigWithSSR.rest.ssrBaseUrl;
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(ssrBaseUrl + '/items');
+        expect(req.request.url).toBe(ssrBaseUrl + '/items');
+        req.flush({});
+        httpMock.verify();
+      });
+
+      it('should not replace any query param containing the base URL', () => {
+        const url = 'http://api.example.com/server/items?url=http://api.example.com/server/item/1';
+        const ssrBaseUrl = appConfigWithSSR.rest.ssrBaseUrl;
+
+        httpClient.get(url).subscribe((response) => {
+          expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne(ssrBaseUrl + '/items?url=http://api.example.com/server/item/1');
+        expect(req.request.url).toBe(ssrBaseUrl + '/items?url=http://api.example.com/server/item/1');
+        req.flush({});
+        httpMock.verify();
+      });
+    });
+  });
+});

--- a/src/app/core/dspace-rest/dspace-rest.interceptor.ts
+++ b/src/app/core/dspace-rest/dspace-rest.interceptor.ts
@@ -1,0 +1,52 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+} from '@angular/common/http';
+import {
+  Inject,
+  Injectable,
+  PLATFORM_ID,
+} from '@angular/core';
+import { Observable } from 'rxjs';
+
+import {
+  APP_CONFIG,
+  AppConfig,
+} from '../../../config/app-config.interface';
+import { isEmpty } from '../../shared/empty.util';
+
+@Injectable()
+/**
+ * This Interceptor is used to use the configured base URL for the request made during SSR execution
+ */
+export class DspaceRestInterceptor implements HttpInterceptor {
+
+  /**
+   * Contains the configured application base URL
+   * @protected
+   */
+  protected baseUrl: string;
+  protected ssrBaseUrl: string;
+
+  constructor(
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject(PLATFORM_ID) private platformId: string,
+  ) {
+    this.baseUrl = this.appConfig.rest.baseUrl;
+    this.ssrBaseUrl = this.appConfig.rest.ssrBaseUrl;
+  }
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (isPlatformBrowser(this.platformId) || isEmpty(this.ssrBaseUrl) || this.baseUrl === this.ssrBaseUrl) {
+      return next.handle(request);
+    }
+
+    // Different SSR Base URL specified so replace it in the current request url
+    const url = request.url.replace(this.baseUrl, this.ssrBaseUrl);
+    const newRequest: HttpRequest<any> = request.clone({ url });
+    return next.handle(newRequest);
+  }
+}

--- a/src/app/core/services/server-hard-redirect.service.spec.ts
+++ b/src/app/core/services/server-hard-redirect.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
+import { environment } from '../../../environments/environment.test';
 import { ServerHardRedirectService } from './server-hard-redirect.service';
 
 describe('ServerHardRedirectService', () => {
@@ -7,7 +8,7 @@ describe('ServerHardRedirectService', () => {
   const mockRequest = jasmine.createSpyObj(['get']);
   const mockResponse = jasmine.createSpyObj(['redirect', 'end']);
 
-  const service: ServerHardRedirectService = new ServerHardRedirectService(mockRequest, mockResponse);
+  let service: ServerHardRedirectService = new ServerHardRedirectService(environment, mockRequest, mockResponse);
   const origin = 'https://test-host.com:4000';
 
   beforeEach(() => {
@@ -65,6 +66,25 @@ describe('ServerHardRedirectService', () => {
 
     it('should return the location origin', () => {
       expect(service.getCurrentOrigin()).toEqual(origin);
+    });
+  });
+
+  describe('when SSR base url is set', () => {
+    const redirect = 'https://private-url:4000/server/api/bitstreams/uuid';
+    const replacedUrl = 'https://public-url/server/api/bitstreams/uuid';
+    const environmentWithSSRUrl: any = { ...environment, ...{ ...environment.rest, rest: {
+      ssrBaseUrl: 'https://private-url:4000/server',
+      baseUrl: 'https://public-url/server',
+    } } };
+    service = new ServerHardRedirectService(environmentWithSSRUrl, mockRequest, mockResponse);
+
+    beforeEach(() => {
+      service.redirect(redirect);
+    });
+
+    it('should perform a 302 redirect', () => {
+      expect(mockResponse.redirect).toHaveBeenCalledWith(302, replacedUrl);
+      expect(mockResponse.end).toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/utils/safe-url-pipe.ts
+++ b/src/app/shared/utils/safe-url-pipe.ts
@@ -16,6 +16,6 @@ import { DomSanitizer } from '@angular/platform-browser';
 export class SafeUrlPipe implements PipeTransform {
   constructor(private domSanitizer: DomSanitizer) { }
   transform(url) {
-    return this.domSanitizer.bypassSecurityTrustResourceUrl(url);
+    return url == null ? null : this.domSanitizer.bypassSecurityTrustResourceUrl(url);
   }
 }

--- a/src/app/thumbnail/thumbnail.component.html
+++ b/src/app/thumbnail/thumbnail.component.html
@@ -1,4 +1,4 @@
-<div class="thumbnail" [class.limit-width]="limitWidth" *ngVar="(isLoading$ | async) as isLoading">
+<div class="thumbnail" [class.limit-width]="limitWidth">
   <div *ngIf="isLoading" class="thumbnail-content outer">
     <div class="inner">
       <div class="centered">
@@ -6,16 +6,14 @@
       </div>
     </div>
   </div>
-  <ng-container *ngVar="(src$ | async) as src">
-    <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
-    <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
-         [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
-    <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
-      <div class="inner">
-        <div class="thumbnail-placeholder centered lead">
-          {{ placeholder | translate }}
-        </div>
+  <!-- don't use *ngIf="!isLoading" so the thumbnail can load in while the animation is playing -->
+  <img *ngIf="src !== null" class="thumbnail-content img-fluid" [ngClass]="{'d-none': isLoading}"
+       [src]="src | dsSafeUrl" [alt]="alt | translate" (error)="errorHandler()" (load)="successHandler()">
+  <div *ngIf="src === null && !isLoading" class="thumbnail-content outer">
+    <div class="inner">
+      <div class="thumbnail-placeholder centered lead">
+        {{ placeholder | translate }}
       </div>
     </div>
-  </ng-container>
+  </div>
 </div>

--- a/src/app/thumbnail/thumbnail.component.spec.ts
+++ b/src/app/thumbnail/thumbnail.component.spec.ts
@@ -2,6 +2,7 @@ import {
   DebugElement,
   Pipe,
   PipeTransform,
+  PLATFORM_ID,
 } from '@angular/core';
 import {
   ComponentFixture,
@@ -48,298 +49,261 @@ describe('ThumbnailComponent', () => {
   let authService;
   let authorizationService;
   let fileService;
+  let spy;
 
-  beforeEach(waitForAsync(() => {
-    authService = jasmine.createSpyObj('AuthService', {
-      isAuthenticated: observableOf(true),
-    });
-    authorizationService = jasmine.createSpyObj('AuthorizationService', {
-      isAuthorized: observableOf(true),
-    });
-    fileService = jasmine.createSpyObj('FileService', {
-      retrieveFileDownloadLink: null,
-    });
-    fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
-
-    TestBed.configureTestingModule({
-      imports: [
-        TranslateModule.forRoot(),
-        ThumbnailComponent,
-        SafeUrlPipe,
-        MockTranslatePipe,
-        VarDirective,
-      ],
-      providers: [
-        { provide: AuthService, useValue: authService },
-        { provide: AuthorizationDataService, useValue: authorizationService },
-        { provide: FileService, useValue: fileService },
-        { provide: ThemeService, useValue: getMockThemeService() },
-      ],
-    }).overrideComponent(ThumbnailComponent, {
-      add: {
-        imports: [MockTranslatePipe],
-      },
-    })
-      .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(ThumbnailComponent);
-    fixture.detectChanges();
-
-    authService = TestBed.inject(AuthService);
-
-    comp = fixture.componentInstance; // ThumbnailComponent test instance
-    de = fixture.debugElement.query(By.css('div.thumbnail'));
-    el = de.nativeElement;
-  });
-
-  describe('loading', () => {
-    it('should start out with isLoading$ true', () => {
-      expect(comp.isLoading$.getValue()).toBeTrue();
-    });
-
-    it('should set isLoading$ to false once an image is successfully loaded', () => {
-      comp.setSrc('http://bit.stream');
-      fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
-      expect(comp.isLoading$.getValue()).toBeFalse();
-    });
-
-    it('should set isLoading$ to false once the src is set to null', () => {
-      comp.setSrc(null);
-      expect(comp.isLoading$.getValue()).toBeFalse();
-    });
-
-    it('should show a loading animation while isLoading$ is true', () => {
-      expect(de.query(By.css('ds-loading'))).toBeTruthy();
-
-      comp.isLoading$.next(false);
-      fixture.detectChanges();
-      expect(fixture.debugElement.query(By.css('ds-loading'))).toBeFalsy();
-    });
-
-    describe('with a thumbnail image', () => {
-      beforeEach(() => {
-        comp.src$.next('https://bit.stream');
-        fixture.detectChanges();
+  describe('when platform is browser', () => {
+    beforeEach(waitForAsync(() => {
+      authService = jasmine.createSpyObj('AuthService', {
+        isAuthenticated: observableOf(true),
       });
-
-      it('should render but hide the image while loading and show it once done', () => {
-        let img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-        expect(img).toBeTruthy();
-        expect(img.classes['d-none']).toBeTrue();
-
-        comp.isLoading$.next(false);
-        fixture.detectChanges();
-        img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-        expect(img).toBeTruthy();
-        expect(img.classes['d-none']).toBeFalsy();
+      authorizationService = jasmine.createSpyObj('AuthorizationService', {
+        isAuthorized: observableOf(true),
       });
-
-    });
-
-    describe('without a thumbnail image', () => {
-      beforeEach(() => {
-        comp.src$.next(null);
-        fixture.detectChanges();
+      fileService = jasmine.createSpyObj('FileService', {
+        retrieveFileDownloadLink: null,
       });
+      fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
 
-      it('should only show the HTML placeholder once done loading', () => {
-        expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
-
-        comp.isLoading$.next(false);
-        fixture.detectChanges();
-        expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
-      });
-    });
-
-  });
-
-  const errorHandler = () => {
-    let setSrcSpy;
+      TestBed.configureTestingModule({
+        imports: [
+          TranslateModule.forRoot(),
+          ThumbnailComponent,
+          SafeUrlPipe,
+          MockTranslatePipe,
+          VarDirective,
+        ],
+        providers: [
+          { provide: AuthService, useValue: authService },
+          { provide: AuthorizationDataService, useValue: authorizationService },
+          { provide: FileService, useValue: fileService },
+          { provide: ThemeService, useValue: getMockThemeService() },
+          { provide: PLATFORM_ID, useValue: 'browser' },
+        ],
+      }).overrideComponent(ThumbnailComponent, {
+        add: {
+          imports: [MockTranslatePipe],
+        },
+      })
+        .compileComponents();
+    }));
 
     beforeEach(() => {
-      // disconnect error handler to be sure it's only called once
-      const img = fixture.debugElement.query(By.css('img.thumbnail-content'));
-      img.nativeNode.onerror = null;
+      fixture = TestBed.createComponent(ThumbnailComponent);
+      fixture.detectChanges();
 
-      comp.ngOnChanges({});
-      setSrcSpy = spyOn(comp, 'setSrc').and.callThrough();
+      authService = TestBed.inject(AuthService);
+
+      comp = fixture.componentInstance; // ThumbnailComponent test instance
+      de = fixture.debugElement.query(By.css('div.thumbnail'));
+      el = de.nativeElement;
     });
 
-    describe('retry with authentication token', () => {
-      it('should remember that it already retried once', () => {
-        expect(comp.retriedWithToken).toBeFalse();
-        comp.errorHandler();
-        expect(comp.retriedWithToken).toBeTrue();
+    describe('loading', () => {
+      it('should start out with isLoading$ true', () => {
+        expect(comp.isLoading).toBeTrue();
       });
 
-      describe('if not logged in', () => {
+      it('should set isLoading$ to false once an image is successfully loaded', () => {
+        comp.setSrc('http://bit.stream');
+        fixture.debugElement.query(By.css('img.thumbnail-content')).triggerEventHandler('load', new Event('load'));
+        expect(comp.isLoading).toBeFalse();
+      });
+
+      it('should set isLoading$ to false once the src is set to null', () => {
+        comp.setSrc(null);
+        expect(comp.isLoading).toBeFalse();
+      });
+
+      it('should show a loading animation while isLoading$ is true', () => {
+        expect(de.query(By.css('ds-loading'))).toBeTruthy();
+
+        comp.isLoading = false;
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('ds-loading'))).toBeFalsy();
+      });
+
+      describe('with a thumbnail image', () => {
         beforeEach(() => {
-          authService.isAuthenticated.and.returnValue(observableOf(false));
+          comp.src = 'https://bit.stream';
+          fixture.detectChanges();
         });
 
-        it('should fall back to default', () => {
+        it('should render but hide the image while loading and show it once done', () => {
+          let img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+          expect(img).toBeTruthy();
+          expect(img.classes['d-none']).toBeTrue();
+
+          comp.isLoading = false;
+          fixture.detectChanges();
+          img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+          expect(img).toBeTruthy();
+          expect(img.classes['d-none']).toBeFalsy();
+        });
+
+      });
+
+      describe('without a thumbnail image', () => {
+        beforeEach(() => {
+          comp.src = null;
+          fixture.detectChanges();
+        });
+
+        it('should only show the HTML placeholder once done loading', () => {
+          expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeFalsy();
+
+          comp.isLoading = false;
+          fixture.detectChanges();
+          expect(fixture.debugElement.query(By.css('div.thumbnail-placeholder'))).toBeTruthy();
+        });
+      });
+
+    });
+
+    const errorHandler = () => {
+      let setSrcSpy;
+
+      beforeEach(() => {
+        // disconnect error handler to be sure it's only called once
+        const img = fixture.debugElement.query(By.css('img.thumbnail-content'));
+        img.nativeNode.onerror = null;
+
+        comp.ngOnChanges({});
+        setSrcSpy = spyOn(comp, 'setSrc').and.callThrough();
+      });
+
+      describe('retry with authentication token', () => {
+        it('should remember that it already retried once', () => {
+          expect(comp.retriedWithToken).toBeFalse();
           comp.errorHandler();
-          expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-        });
-      });
-
-      describe('if logged in', () => {
-        beforeEach(() => {
-          authService.isAuthenticated.and.returnValue(observableOf(true));
+          expect(comp.retriedWithToken).toBeTrue();
         });
 
-        describe('and authorized to download the thumbnail', () => {
+        describe('if not logged in', () => {
           beforeEach(() => {
-            authorizationService.isAuthorized.and.returnValue(observableOf(true));
-          });
-
-          it('should add an authentication token to the thumbnail URL', () => {
-            comp.errorHandler();
-
-            if ((comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
-              // If we failed to retrieve the Bitstream in the first place, fall back to the default
-              expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-            } else {
-              expect(setSrcSpy).toHaveBeenCalledWith(CONTENT + '?authentication-token=fake');
-            }
-          });
-        });
-
-        describe('but not authorized to download the thumbnail', () => {
-          beforeEach(() => {
-            authorizationService.isAuthorized.and.returnValue(observableOf(false));
+            authService.isAuthenticated.and.returnValue(observableOf(false));
           });
 
           it('should fall back to default', () => {
             comp.errorHandler();
-
             expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-
-            // We don't need to check authorization if we failed to retrieve the Bitstreamin the first place
-            if (!(comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
-              expect(authorizationService.isAuthorized).toHaveBeenCalled();
-            }
           });
+        });
+
+        describe('if logged in', () => {
+          beforeEach(() => {
+            authService.isAuthenticated.and.returnValue(observableOf(true));
+          });
+
+          describe('and authorized to download the thumbnail', () => {
+            beforeEach(() => {
+              authorizationService.isAuthorized.and.returnValue(observableOf(true));
+            });
+
+            it('should add an authentication token to the thumbnail URL', () => {
+              comp.errorHandler();
+
+              if ((comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
+                // If we failed to retrieve the Bitstream in the first place, fall back to the default
+                expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+              } else {
+                expect(setSrcSpy).toHaveBeenCalledWith(CONTENT + '?authentication-token=fake');
+              }
+            });
+          });
+
+          describe('but not authorized to download the thumbnail', () => {
+            beforeEach(() => {
+              authorizationService.isAuthorized.and.returnValue(observableOf(false));
+            });
+
+            it('should fall back to default', () => {
+              comp.errorHandler();
+
+              expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+
+              // We don't need to check authorization if we failed to retrieve the Bitstreamin the first place
+              if (!(comp.thumbnail as RemoteData<Bitstream>)?.hasFailed) {
+                expect(authorizationService.isAuthorized).toHaveBeenCalled();
+              }
+            });
+          });
+        });
+      });
+
+      describe('after retrying with token', () => {
+        beforeEach(() => {
+          comp.retriedWithToken = true;
+        });
+
+        it('should fall back to default', () => {
+          comp.errorHandler();
+          expect(authService.isAuthenticated).not.toHaveBeenCalled();
+          expect(fileService.retrieveFileDownloadLink).not.toHaveBeenCalled();
+          expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
+        });
+      });
+    };
+
+    describe('fallback', () => {
+      describe('if there is a default image', () => {
+        it('should display the default image', () => {
+          comp.src = 'http://bit.stream';
+          comp.defaultImage = 'http://default.img';
+          comp.errorHandler();
+          expect(comp.src).toBe(comp.defaultImage);
+        });
+
+        it('should include the alt text', () => {
+          comp.src = 'http://bit.stream';
+          comp.defaultImage = 'http://default.img';
+          comp.errorHandler();
+
+          fixture.detectChanges();
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
+          expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
+        });
+      });
+
+      describe('if there is no default image', () => {
+        it('should display the HTML placeholder', () => {
+          comp.src = 'http://default.img';
+          comp.defaultImage = null;
+          comp.errorHandler();
+          expect(comp.src).toBe(null);
+
+          fixture.detectChanges();
+          const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
+          expect(placeholder.innerHTML).toContain('TRANSLATED ' + comp.placeholder);
         });
       });
     });
 
-    describe('after retrying with token', () => {
+    describe('with thumbnail as Bitstream', () => {
+      let thumbnail;
       beforeEach(() => {
-        comp.retriedWithToken = true;
-      });
-
-      it('should fall back to default', () => {
-        comp.errorHandler();
-        expect(authService.isAuthenticated).not.toHaveBeenCalled();
-        expect(fileService.retrieveFileDownloadLink).not.toHaveBeenCalled();
-        expect(setSrcSpy).toHaveBeenCalledWith(comp.defaultImage);
-      });
-    });
-  };
-
-  describe('fallback', () => {
-    describe('if there is a default image', () => {
-      it('should display the default image', () => {
-        comp.src$.next('http://bit.stream');
-        comp.defaultImage = 'http://default.img';
-        comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(comp.defaultImage);
-      });
-
-      it('should include the alt text', () => {
-        comp.src$.next('http://bit.stream');
-        comp.defaultImage = 'http://default.img';
-        comp.errorHandler();
-
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
-      });
-    });
-
-    describe('if there is no default image', () => {
-      it('should display the HTML placeholder', () => {
-        comp.src$.next('http://default.img');
-        comp.defaultImage = null;
-        comp.errorHandler();
-        expect(comp.src$.getValue()).toBe(null);
-
-        fixture.detectChanges();
-        const placeholder = fixture.debugElement.query(By.css('div.thumbnail-placeholder')).nativeElement;
-        expect(placeholder.innerHTML).toContain('TRANSLATED ' + comp.placeholder);
-      });
-    });
-  });
-
-  describe('with thumbnail as Bitstream', () => {
-    let thumbnail;
-    beforeEach(() => {
-      thumbnail = new Bitstream();
-      thumbnail._links = {
-        self: { href: 'self.url' },
-        bundle: { href: 'bundle.url' },
-        format: { href: 'format.url' },
-        content: { href: CONTENT },
-        thumbnail: undefined,
-      };
-      comp.thumbnail = thumbnail;
-    });
-
-    describe('if content can be loaded', () => {
-      it('should display an image', () => {
-        comp.ngOnChanges({});
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
-      });
-
-      it('should include the alt text', () => {
-        comp.ngOnChanges({});
-        fixture.detectChanges();
-        const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
-        expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
-      });
-    });
-
-    describe('if content can\'t be loaded', () => {
-      errorHandler();
-    });
-  });
-
-  describe('with thumbnail as RemoteData<Bitstream>', () => {
-    let thumbnail: Bitstream;
-
-    beforeEach(() => {
-      thumbnail = new Bitstream();
-      thumbnail._links = {
-        self: { href: 'self.url' },
-        bundle: { href: 'bundle.url' },
-        format: { href: 'format.url' },
-        content: { href: CONTENT },
-        thumbnail: undefined,
-      };
-    });
-
-    describe('if RemoteData succeeded', () => {
-      beforeEach(() => {
-        comp.thumbnail = createSuccessfulRemoteDataObject(thumbnail);
+        thumbnail = new Bitstream();
+        thumbnail._links = {
+          self: { href: 'self.url' },
+          bundle: { href: 'bundle.url' },
+          format: { href: 'format.url' },
+          content: { href: CONTENT },
+          thumbnail: undefined,
+        };
+        comp.thumbnail = thumbnail;
       });
 
       describe('if content can be loaded', () => {
         it('should display an image', () => {
           comp.ngOnChanges({});
           fixture.detectChanges();
-          const image: HTMLElement = de.query(By.css('img')).nativeElement;
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
           expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
         });
 
-        it('should display the alt text', () => {
+        it('should include the alt text', () => {
           comp.ngOnChanges({});
           fixture.detectChanges();
-          const image: HTMLElement = de.query(By.css('img')).nativeElement;
+          const image: HTMLElement = fixture.debugElement.query(By.css('img')).nativeElement;
           expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
         });
       });
@@ -349,16 +313,117 @@ describe('ThumbnailComponent', () => {
       });
     });
 
-    describe('if RemoteData failed', () => {
+    describe('with thumbnail as RemoteData<Bitstream>', () => {
+      let thumbnail: Bitstream;
+
       beforeEach(() => {
-        comp.thumbnail = createFailedRemoteDataObject();
+        thumbnail = new Bitstream();
+        thumbnail._links = {
+          self: { href: 'self.url' },
+          bundle: { href: 'bundle.url' },
+          format: { href: 'format.url' },
+          content: { href: CONTENT },
+          thumbnail: undefined,
+        };
       });
 
-      it('should show the default image', () => {
-        comp.defaultImage = 'default/image.jpg';
-        comp.ngOnChanges({});
-        expect(comp.src$.getValue()).toBe('default/image.jpg');
+      describe('if RemoteData succeeded', () => {
+        beforeEach(() => {
+          comp.thumbnail = createSuccessfulRemoteDataObject(thumbnail);
+        });
+
+        describe('if content can be loaded', () => {
+          it('should display an image', () => {
+            comp.ngOnChanges({});
+            fixture.detectChanges();
+            const image: HTMLElement = de.query(By.css('img')).nativeElement;
+            expect(image.getAttribute('src')).toBe(thumbnail._links.content.href);
+          });
+
+          it('should display the alt text', () => {
+            comp.ngOnChanges({});
+            fixture.detectChanges();
+            const image: HTMLElement = de.query(By.css('img')).nativeElement;
+            expect(image.getAttribute('alt')).toBe('TRANSLATED ' + comp.alt);
+          });
+        });
+
+        describe('if content can\'t be loaded', () => {
+          errorHandler();
+        });
+      });
+
+      describe('if RemoteData failed', () => {
+        beforeEach(() => {
+          comp.thumbnail = createFailedRemoteDataObject();
+        });
+
+        it('should show the default image', () => {
+          comp.defaultImage = 'default/image.jpg';
+          comp.ngOnChanges({});
+          expect(comp.src).toBe('default/image.jpg');
+        });
       });
     });
+  });
+
+  describe('when platform is server', () => {
+    beforeEach(waitForAsync(() => {
+
+      authService = jasmine.createSpyObj('AuthService', {
+        isAuthenticated: observableOf(true),
+      });
+      authorizationService = jasmine.createSpyObj('AuthorizationService', {
+        isAuthorized: observableOf(true),
+      });
+      fileService = jasmine.createSpyObj('FileService', {
+        retrieveFileDownloadLink: null,
+      });
+      fileService.retrieveFileDownloadLink.and.callFake((url) => observableOf(`${url}?authentication-token=fake`));
+
+      TestBed.configureTestingModule({
+        imports: [
+          TranslateModule.forRoot(),
+          ThumbnailComponent,
+          SafeUrlPipe,
+          MockTranslatePipe,
+          VarDirective,
+        ],
+        providers: [
+          { provide: AuthService, useValue: authService },
+          { provide: AuthorizationDataService, useValue: authorizationService },
+          { provide: FileService, useValue: fileService },
+          { provide: ThemeService, useValue: getMockThemeService() },
+          { provide: PLATFORM_ID, useValue: 'server' },
+        ],
+      }).overrideComponent(ThumbnailComponent, {
+        add: {
+          imports: [MockTranslatePipe],
+        },
+      })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(ThumbnailComponent);
+      spyOn(fixture.componentInstance, 'setSrc').and.callThrough();
+      fixture.detectChanges();
+
+      authService = TestBed.inject(AuthService);
+
+      comp = fixture.componentInstance; // ThumbnailComponent test instance
+      de = fixture.debugElement.query(By.css('div.thumbnail'));
+      el = de.nativeElement;
+    });
+
+    it('should start out with isLoading$ true', () => {
+      expect(comp.isLoading).toBeTrue();
+      expect(de.query(By.css('ds-loading'))).toBeTruthy();
+    });
+
+    it('should not call setSrc', () => {
+      expect(comp.setSrc).not.toHaveBeenCalled();
+    });
+
   });
 });

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -11,10 +11,7 @@ import {
   SimpleChanges,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  BehaviorSubject,
-  of as observableOf,
-} from 'rxjs';
+import { of as observableOf } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 
 import { AuthService } from '../core/auth/auth.service';
@@ -58,7 +55,7 @@ export class ThumbnailComponent implements OnChanges {
   /**
    * The src attribute used in the template to render the image.
    */
-  src$ = new BehaviorSubject<string>(undefined);
+  src: string = undefined;
 
   retriedWithToken = false;
 
@@ -81,7 +78,7 @@ export class ThumbnailComponent implements OnChanges {
    * Whether the thumbnail is currently loading
    * Start out as true to avoid flashing the alt text while a thumbnail is being loaded.
    */
-  isLoading$ = new BehaviorSubject(true);
+  isLoading = true;
 
   constructor(
     @Inject(PLATFORM_ID) private platformID: any,
@@ -137,7 +134,7 @@ export class ThumbnailComponent implements OnChanges {
    * Otherwise, fall back to the default image or a HTML placeholder
    */
   errorHandler() {
-    const src = this.src$.getValue();
+    const src = this.src;
     const thumbnail = this.bitstream;
     const thumbnailSrc = thumbnail?._links?.content?.href;
 
@@ -189,9 +186,9 @@ export class ThumbnailComponent implements OnChanges {
    * @param src
    */
   setSrc(src: string): void {
-    this.src$.next(src);
+    this.src = src;
     if (src === null) {
-      this.isLoading$.next(false);
+      this.isLoading = false;
     }
   }
 
@@ -199,6 +196,6 @@ export class ThumbnailComponent implements OnChanges {
    * Stop the loading animation once the thumbnail is successfully loaded
    */
   successHandler() {
-    this.isLoading$.next(false);
+    this.isLoading = false;
   }
 }

--- a/src/app/thumbnail/thumbnail.component.ts
+++ b/src/app/thumbnail/thumbnail.component.ts
@@ -1,8 +1,13 @@
-import { CommonModule } from '@angular/common';
+import {
+  CommonModule,
+  isPlatformBrowser,
+} from '@angular/common';
 import {
   Component,
+  Inject,
   Input,
   OnChanges,
+  PLATFORM_ID,
   SimpleChanges,
 } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -79,6 +84,7 @@ export class ThumbnailComponent implements OnChanges {
   isLoading$ = new BehaviorSubject(true);
 
   constructor(
+    @Inject(PLATFORM_ID) private platformID: any,
     protected auth: AuthService,
     protected authorizationService: AuthorizationDataService,
     protected fileService: FileService,
@@ -90,16 +96,18 @@ export class ThumbnailComponent implements OnChanges {
    * Use a default image if no actual image is available.
    */
   ngOnChanges(changes: SimpleChanges): void {
-    if (hasNoValue(this.thumbnail)) {
-      this.setSrc(this.defaultImage);
-      return;
-    }
+    if (isPlatformBrowser(this.platformID)) {
+      if (hasNoValue(this.thumbnail)) {
+        this.setSrc(this.defaultImage);
+        return;
+      }
 
-    const src = this.contentHref;
-    if (hasValue(src)) {
-      this.setSrc(src);
-    } else {
-      this.setSrc(this.defaultImage);
+      const src = this.contentHref;
+      if (hasValue(src)) {
+        this.setSrc(src);
+      } else {
+        this.setSrc(this.defaultImage);
+      }
     }
   }
 

--- a/src/config/config.server.ts
+++ b/src/config/config.server.ts
@@ -236,6 +236,7 @@ export const buildAppConfig = (destConfigPath?: string): AppConfig => {
   appConfig.rest.port = isNotEmpty(ENV('REST_PORT', true)) ? getNumberFromString(ENV('REST_PORT', true)) : appConfig.rest.port;
   appConfig.rest.nameSpace = isNotEmpty(ENV('REST_NAMESPACE', true)) ? ENV('REST_NAMESPACE', true) : appConfig.rest.nameSpace;
   appConfig.rest.ssl = isNotEmpty(ENV('REST_SSL', true)) ? getBooleanFromString(ENV('REST_SSL', true)) : appConfig.rest.ssl;
+  appConfig.rest.ssrBaseUrl = isNotEmpty(ENV('REST_SSRBASEURL', true)) ? ENV('REST_SSRBASEURL', true) : appConfig.rest.ssrBaseUrl;
 
   // apply build defined production
   appConfig.production = env === 'production';

--- a/src/config/server-config.interface.ts
+++ b/src/config/server-config.interface.ts
@@ -6,4 +6,8 @@ export class ServerConfig implements Config {
   public port: number;
   public nameSpace: string;
   public baseUrl?: string;
+  public ssrBaseUrl?: string;
+  // This boolean will be automatically set on server startup based on whether "baseUrl" and "ssrBaseUrl"
+  // have different values.
+  public hasSsrBaseUrl?: boolean;
 }

--- a/src/config/ssr-config.interface.ts
+++ b/src/config/ssr-config.interface.ts
@@ -20,4 +20,36 @@ export interface SSRConfig extends Config {
    * For improved SSR performance, DSpace defaults this to false (disabled).
    */
   inlineCriticalCss: boolean;
+
+  /**
+   * Enable state transfer from the server-side application to the client-side application.
+   * Defaults to true.
+   *
+   * Note: When using an external application cache layer, it's recommended not to transfer the state to avoid caching it.
+   * Disabling it ensures that dynamic state information is not inadvertently cached, which can improve security and
+   * ensure that users always use the most up-to-date state.
+   */
+  transferState: boolean;
+
+  /**
+   * When a different REST base URL is used for the server-side application, the generated state contains references to
+   * REST resources with the internal URL configured. By default, these internal URLs are replaced with public URLs.
+   * Disable this setting to avoid URL replacement during SSR. In this the state is not transferred to avoid security issues.
+   */
+  replaceRestUrl: boolean;
+
+  /**
+   * Paths to enable SSR for. Defaults to the home page and paths in the sitemap.
+   */
+  paths: Array<string>;
+
+  /**
+   * Whether to enable rendering of search component on SSR
+   */
+  enableSearchComponent: boolean;
+
+  /**
+   * Whether to enable rendering of browse component on SSR
+   */
+  enableBrowseComponent: boolean;
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -8,5 +8,10 @@ export const environment: Partial<BuildConfig> = {
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
+    transferState: true,
+    replaceRestUrl: true,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
   },
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -12,6 +12,11 @@ export const environment: BuildConfig = {
     enabled: true,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
+    transferState: true,
+    replaceRestUrl: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
   },
 
   // Angular express server settings.

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,6 +13,11 @@ export const environment: Partial<BuildConfig> = {
     enabled: false,
     enablePerformanceProfiler: false,
     inlineCriticalCss: false,
+    transferState: true,
+    replaceRestUrl: false,
+    paths: [ '/home', '/items/', '/entities/', '/collections/', '/communities/', '/bitstream/', '/bitstreams/', '/handle/', '/reload/' ],
+    enableSearchComponent: false,
+    enableBrowseComponent: false,
   },
 };
 

--- a/src/modules/app/browser-init.service.ts
+++ b/src/modules/app/browser-init.service.ts
@@ -52,6 +52,7 @@ import {
   APP_CONFIG_STATE,
   AppConfig,
 } from '../../config/app-config.interface';
+import { BuildConfig } from '../../config/build-config.interface';
 import { extendEnvironmentWithAppConfig } from '../../config/config.util';
 import { DefaultAppConfig } from '../../config/default-app-config';
 import { environment } from '../../environments/environment';
@@ -68,7 +69,7 @@ export class BrowserInitService extends InitService {
     protected store: Store<AppState>,
     protected correlationIdService: CorrelationIdService,
     protected transferState: TransferState,
-    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject(APP_CONFIG) protected appConfig: BuildConfig,
     protected translate: TranslateService,
     protected localeService: LocaleService,
     protected angulartics2DSpace: Angulartics2DSpace,
@@ -139,15 +140,20 @@ export class BrowserInitService extends InitService {
    * @private
    */
   private async loadAppState(): Promise<boolean> {
-    const state = this.transferState.get<any>(InitService.NGRX_STATE, null);
-    this.transferState.remove(InitService.NGRX_STATE);
-    this.store.dispatch(new StoreAction(StoreActionTypes.REHYDRATE, state));
-    return lastValueFrom(
-      this.store.select(coreSelector).pipe(
-        find((core: any) => isNotEmpty(core)),
-        map(() => true),
-      ),
-    );
+    // The app state can be transferred only when SSR and CSR are using the same base url for the REST API
+    if (this.appConfig.ssr.transferState) {
+      const state = this.transferState.get<any>(InitService.NGRX_STATE, null);
+      this.transferState.remove(InitService.NGRX_STATE);
+      this.store.dispatch(new StoreAction(StoreActionTypes.REHYDRATE, state));
+      return lastValueFrom(
+        this.store.select(coreSelector).pipe(
+          find((core: any) => isNotEmpty(core)),
+          map(() => true),
+        ),
+      );
+    } else {
+      return Promise.resolve(true);
+    }
   }
 
   private trackAuthTokenExpiration(): void {

--- a/src/modules/app/server-init.service.ts
+++ b/src/modules/app/server-init.service.ts
@@ -21,6 +21,10 @@ import { LocaleService } from '../../app/core/locale/locale.service';
 import { HeadTagService } from '../../app/core/metadata/head-tag.service';
 import { CorrelationIdService } from '../../app/correlation-id/correlation-id.service';
 import { InitService } from '../../app/init.service';
+import {
+  isEmpty,
+  isNotEmpty,
+} from '../../app/shared/empty.util';
 import { MenuService } from '../../app/shared/menu/menu.service';
 import { ThemeService } from '../../app/shared/theme-support/theme.service';
 import { Angulartics2DSpace } from '../../app/statistics/angulartics/dspace-provider';
@@ -29,6 +33,7 @@ import {
   APP_CONFIG_STATE,
   AppConfig,
 } from '../../config/app-config.interface';
+import { BuildConfig } from '../../config/build-config.interface';
 import { environment } from '../../environments/environment';
 
 /**
@@ -40,7 +45,7 @@ export class ServerInitService extends InitService {
     protected store: Store<AppState>,
     protected correlationIdService: CorrelationIdService,
     protected transferState: TransferState,
-    @Inject(APP_CONFIG) protected appConfig: AppConfig,
+    @Inject(APP_CONFIG) protected appConfig: BuildConfig,
     protected translate: TranslateService,
     protected localeService: LocaleService,
     protected angulartics2DSpace: Angulartics2DSpace,
@@ -89,17 +94,27 @@ export class ServerInitService extends InitService {
    * @private
    */
   private saveAppState() {
-    this.transferState.onSerialize(InitService.NGRX_STATE, () => {
-      let state;
-      this.store.pipe(take(1)).subscribe((saveState: any) => {
-        state = saveState;
-      });
+    if (this.appConfig.ssr.transferState && (isEmpty(this.appConfig.rest.ssrBaseUrl) || this.appConfig.ssr.replaceRestUrl)) {
+      this.transferState.onSerialize(InitService.NGRX_STATE, () => {
+        let state;
+        this.store.pipe(take(1)).subscribe((saveState: any) => {
+          state = saveState;
+        });
 
-      return state;
-    });
+        return state;
+      });
+    }
   }
 
   private saveAppConfigForCSR(): void {
-    this.transferState.set<AppConfig>(APP_CONFIG_STATE, environment as AppConfig);
+    if (isNotEmpty(environment.rest.ssrBaseUrl) && environment.rest.baseUrl !== environment.rest.ssrBaseUrl) {
+      // Avoid to transfer ssrBaseUrl in order to prevent security issues
+      const config: AppConfig = Object.assign({}, environment as AppConfig, {
+        rest: Object.assign({}, environment.rest, { ssrBaseUrl: '', hasSsrBaseUrl: true }),
+      });
+      this.transferState.set<AppConfig>(APP_CONFIG_STATE, config);
+    } else {
+      this.transferState.set<AppConfig>(APP_CONFIG_STATE, environment as AppConfig);
+    }
   }
 }


### PR DESCRIPTION
Back-port of "ssrBaseUrl" functionality from
DSpace-angular pull request 3953.

Implements the ability for Angular Universal to
communicate directly with the DRUM back-end
pod, instead of going through the ingress.

This change was needed for the AWS migration.

https://umd-dit.atlassian.net/browse/LIBDRUM-943
