### PR TITLE
LIBDRUM-1005. "Restricted Access" pages return 401/403 to bots

### DIFF
--- a/src/app/restricted-access/restricted-access.component.spec.ts
+++ b/src/app/restricted-access/restricted-access.component.spec.ts
@@ -1,0 +1,331 @@
+import {
+  DatePipe,
+  Location,
+} from '@angular/common';
+import {
+  ComponentFixture,
+  TestBed,
+  waitForAsync,
+} from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  Router,
+} from '@angular/router';
+import { TranslateModule } from '@ngx-translate/core';
+import { of as observableOf } from 'rxjs';
+
+import { AuthService } from '../core/auth/auth.service';
+import { AuthorizationDataService } from '../core/data/feature-authorization/authorization-data.service';
+import { HardRedirectService } from '../core/services/hard-redirect.service';
+import { ServerResponseService } from '../core/services/server-response.service';
+import { Bitstream } from '../core/shared/bitstream.model';
+import { FileService } from '../core/shared/file.service';
+import { createSuccessfulRemoteDataObject } from '../shared/remote-data.utils';
+import { RestrictedAccessComponent } from './restricted-access.component';
+
+describe('RestrictedAccessComponent', () => {
+  let component: RestrictedAccessComponent;
+  let fixture: ComponentFixture<RestrictedAccessComponent>;
+
+  let authService: jasmine.SpyObj<AuthService>;
+  let authorizationService: jasmine.SpyObj<AuthorizationDataService>;
+  let fileService: jasmine.SpyObj<FileService>;
+  let hardRedirectService: jasmine.SpyObj<HardRedirectService>;
+  let serverResponseService: jasmine.SpyObj<ServerResponseService>;
+  let router: jasmine.SpyObj<Router>;
+  let location: jasmine.SpyObj<Location>;
+  let activatedRoute;
+
+  let bitstream: Bitstream;
+
+  function initBitstream(overrides: Partial<Bitstream> = {}): Bitstream {
+    return Object.assign(new Bitstream(), {
+      uuid: 'test-bitstream-uuid',
+      metadata: {
+        'dc.title': [{ value: 'test-file.pdf', language: null, authority: null, confidence: -1, place: 0 }],
+      },
+      _links: {
+        content: { href: 'bitstream-content-link' },
+        self: { href: 'bitstream-self-link' },
+      },
+      // Default in tests to "FOREVER" embargo
+      embargoRestriction: 'FOREVER',
+      ...overrides,
+    });
+  }
+
+  function init(bitstreamOverrides: Partial<Bitstream> = {}) {
+    bitstream = initBitstream(bitstreamOverrides);
+
+    authService = jasmine.createSpyObj('AuthService', {
+      isAuthenticated: observableOf(false),
+      setRedirectUrl: {},
+    });
+
+    authorizationService = jasmine.createSpyObj('AuthorizationDataService', {
+      isAuthorized: observableOf(false),
+    });
+
+    fileService = jasmine.createSpyObj('FileService', {
+      retrieveFileDownloadLink: observableOf('content-url-with-headers'),
+    });
+
+    hardRedirectService = jasmine.createSpyObj('HardRedirectService', {
+      redirect: {},
+    });
+
+    serverResponseService = jasmine.createSpyObj('ServerResponseService', {
+      setUnauthorized: {},
+      setForbidden: {},
+      setNotFound: {},
+      setStatus: {},
+    });
+
+    router = jasmine.createSpyObj('Router', ['navigateByUrl']);
+    // Provide a url property for redirectOn4xx
+    (router as any).url = '/restricted-access/test-bitstream-uuid';
+
+    location = jasmine.createSpyObj('Location', ['back']);
+
+    activatedRoute = {
+      data: observableOf({
+        bitstream: createSuccessfulRemoteDataObject(bitstream),
+      }),
+    };
+  }
+
+  function initTestBed() {
+    TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot(),
+        RestrictedAccessComponent,
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: Router, useValue: router },
+        { provide: AuthorizationDataService, useValue: authorizationService },
+        { provide: AuthService, useValue: authService },
+        { provide: FileService, useValue: fileService },
+        { provide: HardRedirectService, useValue: hardRedirectService },
+        { provide: ServerResponseService, useValue: serverResponseService },
+        { provide: Location, useValue: location },
+        DatePipe,
+      ],
+    }).compileComponents();
+  }
+
+  // Helper function for setting up anonymous tests with a specific embargo
+  // restriction
+  function setupAnonymous(bitstreamOverrides) {
+    beforeEach(waitForAsync(() => {
+      init(bitstreamOverrides);
+      (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(false));
+      (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+      initTestBed();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(RestrictedAccessComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+  }
+
+  // Helper function verifying that a HTTP 401 Unauthorized status code is
+  // set, and that a redirect to the bitstream is not performed.
+  function verify401StatusCodeAndNoRedirectToDownload() {
+    it('should set 401 Unauthorized and not redirect to the file', waitForAsync(() => {
+      fixture.whenStable().then(() => {
+        expect(serverResponseService.setUnauthorized).toHaveBeenCalled();
+      });
+      fixture.whenStable().then(() => {
+        expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+      });
+      fixture.whenStable().then(() => {
+        expect(hardRedirectService.redirect).not.toHaveBeenCalled();
+      });
+    }));
+  }
+
+  describe('when the user is anonymous (not logged in)', () => {
+    describe('when embargoRestriction is FOREVER', () => {
+      setupAnonymous({ embargoRestriction: 'FOREVER' });
+
+      verify401StatusCodeAndNoRedirectToDownload();
+
+      it('should set the restrictedAccessMessage indicating the file is embargoed forever', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.embargo.forever.message');
+        });
+      }));
+    });
+
+    describe('when there is an embargo end date', () => {
+      setupAnonymous({ embargoRestriction: '2199-04-08' });
+
+      verify401StatusCodeAndNoRedirectToDownload();
+
+      it('should set the restrictedAccessMessage indicating an end date', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessMessage.value).toBe(
+            'bitstream.restricted-access.embargo.restricted-until.message');
+        });
+      }));
+    });
+
+    describe('when embargoRestriction is NONE (embargo over, but file is restricted for another reason)', () => {
+      setupAnonymous({ embargoRestriction: 'NONE' });
+
+      verify401StatusCodeAndNoRedirectToDownload();
+
+      it('should set the restrictedAccessMessage to a simple "forbidden" message', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
+        });
+      }));
+    });
+
+    describe('when file is restricted for non-embargo reasons (such as Campus IP restriction)', () => {
+      setupAnonymous({ embargoRestriction:null });
+
+      verify401StatusCodeAndNoRedirectToDownload();
+
+      it('should set the restrictedAccessMessage to a simple "forbidden" message', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
+        });
+      }));
+    });
+
+    describe('when the user is authorized (even if there is an embargo)', () => {
+      beforeEach(waitForAsync(() => {
+        init();
+        (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(false));
+        (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(true));
+        initTestBed();
+      }));
+
+      beforeEach(() => {
+        fixture = TestBed.createComponent(RestrictedAccessComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+
+      it('should redirect to the content link', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(hardRedirectService.redirect).toHaveBeenCalled();
+        });
+      }));
+
+      it('should NOT call setUnauthorized', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should NOT call setForbidden', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+        });
+      }));
+    });
+  });
+
+  describe('when the user is logged in', () => {
+    describe('returns 403 Forbidden when the user is not authorized to access the file', () => {
+      beforeEach(waitForAsync(() => {
+        init();
+        (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(true));
+        (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+        initTestBed();
+      }));
+
+      beforeEach(() => {
+        fixture = TestBed.createComponent(RestrictedAccessComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+
+      it('should call setForbidden on ServerResponseService', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setForbidden).toHaveBeenCalled();
+        });
+      }));
+
+      it('should NOT call setUnauthorized on ServerResponseService', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should NOT redirect to a download', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(hardRedirectService.redirect).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should set the restrictedAccessHeader', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessHeader.value).toBe('bitstream.restricted-access.user.forbidden.header');
+        });
+      }));
+      it('should set the restrictedAccessMessage', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(component.restrictedAccessMessage.value).toBe(
+            'bitstream.restricted-access.user.forbidden.with_file.message');
+        });
+      }));
+    });
+
+    describe('allows access to the file when the user is authorized', () => {
+      beforeEach(waitForAsync(() => {
+        init();
+        (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(true));
+        (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(true));
+        initTestBed();
+      }));
+
+      beforeEach(() => {
+        fixture = TestBed.createComponent(RestrictedAccessComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
+
+      it('should NOT call setUnauthorized', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should NOT call setForbidden', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should redirect to the file download link', waitForAsync(() => {
+        fixture.whenStable().then(() => {
+          expect(hardRedirectService.redirect).toHaveBeenCalledWith('content-url-with-headers');
+        });
+      }));
+    });
+  });
+
+  describe('back()', () => {
+    beforeEach(waitForAsync(() => {
+      init();
+      initTestBed();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(RestrictedAccessComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it('should call location.back()', () => {
+      component.back();
+      expect(location.back).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/restricted-access/restricted-access.component.spec.ts
+++ b/src/app/restricted-access/restricted-access.component.spec.ts
@@ -95,7 +95,7 @@ describe('RestrictedAccessComponent', () => {
   }
 
   function initTestBed() {
-    TestBed.configureTestingModule({
+    void TestBed.configureTestingModule({
       imports: [
         TranslateModule.forRoot(),
         RestrictedAccessComponent,

--- a/src/app/restricted-access/restricted-access.component.spec.ts
+++ b/src/app/restricted-access/restricted-access.component.spec.ts
@@ -116,7 +116,7 @@ describe('RestrictedAccessComponent', () => {
 
   // Helper function for setting up anonymous tests with a specific embargo
   // restriction
-  function setupAnonymous(bitstreamOverrides) {
+  function setupAnonymous(bitstreamOverrides: Partial<Bitstream>) {
     beforeEach(waitForAsync(() => {
       init(bitstreamOverrides);
       (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(false));
@@ -134,17 +134,11 @@ describe('RestrictedAccessComponent', () => {
   // Helper function verifying that a HTTP 401 Unauthorized status code is
   // set, and that a redirect to the bitstream is not performed.
   function verify401StatusCodeAndNoRedirectToDownload() {
-    it('should set 401 Unauthorized and not redirect to the file', waitForAsync(() => {
-      fixture.whenStable().then(() => {
-        expect(serverResponseService.setUnauthorized).toHaveBeenCalled();
-      });
-      fixture.whenStable().then(() => {
-        expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
-      });
-      fixture.whenStable().then(() => {
-        expect(hardRedirectService.redirect).not.toHaveBeenCalled();
-      });
-    }));
+    it('should set 401 Unauthorized and not redirect to the file', () => {
+      expect(serverResponseService.setUnauthorized).toHaveBeenCalled();
+      expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+      expect(hardRedirectService.redirect).not.toHaveBeenCalled();
+    });
   }
 
   describe('when the user is anonymous (not logged in)', () => {
@@ -154,9 +148,7 @@ describe('RestrictedAccessComponent', () => {
       verify401StatusCodeAndNoRedirectToDownload();
 
       it('should set the restrictedAccessMessage indicating the file is embargoed forever', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.embargo.forever.message');
-        });
+        expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.embargo.forever.message');
       }));
     });
 
@@ -165,12 +157,10 @@ describe('RestrictedAccessComponent', () => {
 
       verify401StatusCodeAndNoRedirectToDownload();
 
-      it('should set the restrictedAccessMessage indicating an end date', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessMessage.value).toBe(
-            'bitstream.restricted-access.embargo.restricted-until.message');
-        });
-      }));
+      it('should set the restrictedAccessMessage indicating an end date', () => {
+        expect(component.restrictedAccessMessage.value).toBe(
+          'bitstream.restricted-access.embargo.restricted-until.message');
+      });
     });
 
     describe('when embargoRestriction is NONE (embargo over, but file is restricted for another reason)', () => {
@@ -178,11 +168,9 @@ describe('RestrictedAccessComponent', () => {
 
       verify401StatusCodeAndNoRedirectToDownload();
 
-      it('should set the restrictedAccessMessage to a simple "forbidden" message', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
-        });
-      }));
+      it('should set the restrictedAccessMessage to a simple "forbidden" message', () => {
+        expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
+      });
     });
 
     describe('when file is restricted for non-embargo reasons (such as Campus IP restriction)', () => {
@@ -190,14 +178,12 @@ describe('RestrictedAccessComponent', () => {
 
       verify401StatusCodeAndNoRedirectToDownload();
 
-      it('should set the restrictedAccessMessage to a simple "forbidden" message', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
-        });
-      }));
+      it('should set the restrictedAccessMessage to a simple "forbidden" message', () => {
+        expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.anonymous.forbidden.message');
+      });
     });
 
-    describe('when the user is authorized (even if there is an embargo)', () => {
+    describe('but the user is authorized (even if there is an embargo)', () => {
       beforeEach(waitForAsync(() => {
         init();
         (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(false));
@@ -211,23 +197,17 @@ describe('RestrictedAccessComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should redirect to the content link', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(hardRedirectService.redirect).toHaveBeenCalled();
-        });
-      }));
+      it('should redirect to the content link', () => {
+        expect(hardRedirectService.redirect).toHaveBeenCalled();
+      });
 
-      it('should NOT call setUnauthorized', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
-        });
-      }));
+      it('should NOT call setUnauthorized', () => {
+        expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+      });
 
-      it('should NOT call setForbidden', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
-        });
-      }));
+      it('should NOT call setForbidden', () => {
+        expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -246,34 +226,45 @@ describe('RestrictedAccessComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should call setForbidden on ServerResponseService', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setForbidden).toHaveBeenCalled();
-        });
+      it('should call setForbidden on ServerResponseService', () => {
+        expect(serverResponseService.setForbidden).toHaveBeenCalled();
+      });
+
+      it('should NOT call setUnauthorized on ServerResponseService', () => {
+        expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+      });
+
+      it('should NOT redirect to a download', () => {
+        expect(hardRedirectService.redirect).not.toHaveBeenCalled();
+      });
+
+      it('should set the restrictedAccessHeader', () => {
+        expect(component.restrictedAccessHeader.value).toBe('bitstream.restricted-access.user.forbidden.header');
+      });
+
+      it('should set the restrictedAccessMessage', () => {
+        expect(component.restrictedAccessMessage.value).toBe(
+          'bitstream.restricted-access.user.forbidden.with_file.message');
+      });
+    });
+
+    describe('returns 403 Forbidden with a generic message when no filename is not provided', () => {
+      beforeEach(waitForAsync(() => {
+        init({ metadata: {} });
+        (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(true));
+        (authorizationService.isAuthorized as jasmine.Spy).and.returnValue(observableOf(false));
+        initTestBed();
       }));
 
-      it('should NOT call setUnauthorized on ServerResponseService', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
-        });
-      }));
+      beforeEach(() => {
+        fixture = TestBed.createComponent(RestrictedAccessComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+      });
 
-      it('should NOT redirect to a download', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(hardRedirectService.redirect).not.toHaveBeenCalled();
-        });
-      }));
-
-      it('should set the restrictedAccessHeader', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessHeader.value).toBe('bitstream.restricted-access.user.forbidden.header');
-        });
-      }));
-      it('should set the restrictedAccessMessage', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(component.restrictedAccessMessage.value).toBe(
-            'bitstream.restricted-access.user.forbidden.with_file.message');
-        });
+      it('should set the generic forbidden message', waitForAsync(() => {
+        expect(component.restrictedAccessMessage.value).toBe(
+          'bitstream.restricted-access.user.forbidden.generic.message');
       }));
     });
 
@@ -291,23 +282,17 @@ describe('RestrictedAccessComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should NOT call setUnauthorized', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
-        });
-      }));
+      it('should NOT call setUnauthorized', () => {
+        expect(serverResponseService.setUnauthorized).not.toHaveBeenCalled();
+      });
 
-      it('should NOT call setForbidden', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
-        });
-      }));
+      it('should NOT call setForbidden', () => {
+        expect(serverResponseService.setForbidden).not.toHaveBeenCalled();
+      });
 
-      it('should redirect to the file download link', waitForAsync(() => {
-        fixture.whenStable().then(() => {
-          expect(hardRedirectService.redirect).toHaveBeenCalledWith('content-url-with-headers');
-        });
-      }));
+      it('should redirect to the file download link', () => {
+        expect(hardRedirectService.redirect).toHaveBeenCalledWith('content-url-with-headers');
+      });
     });
   });
 

--- a/src/app/restricted-access/restricted-access.component.spec.ts
+++ b/src/app/restricted-access/restricted-access.component.spec.ts
@@ -147,9 +147,9 @@ describe('RestrictedAccessComponent', () => {
 
       verify401StatusCodeAndNoRedirectToDownload();
 
-      it('should set the restrictedAccessMessage indicating the file is embargoed forever', waitForAsync(() => {
+      it('should set the restrictedAccessMessage indicating the file is embargoed forever', () => {
         expect(component.restrictedAccessMessage.value).toBe('bitstream.restricted-access.embargo.forever.message');
-      }));
+      });
     });
 
     describe('when there is an embargo end date', () => {
@@ -248,7 +248,7 @@ describe('RestrictedAccessComponent', () => {
       });
     });
 
-    describe('returns 403 Forbidden with a generic message when no filename is not provided', () => {
+    describe('returns 403 Forbidden with a generic message when a filename is not provided', () => {
       beforeEach(waitForAsync(() => {
         init({ metadata: {} });
         (authService.isAuthenticated as jasmine.Spy).and.returnValue(observableOf(true));
@@ -262,10 +262,10 @@ describe('RestrictedAccessComponent', () => {
         fixture.detectChanges();
       });
 
-      it('should set the generic forbidden message', waitForAsync(() => {
+      it('should set the generic forbidden message', () => {
         expect(component.restrictedAccessMessage.value).toBe(
           'bitstream.restricted-access.user.forbidden.generic.message');
-      }));
+      });
     });
 
     describe('allows access to the file when the user is authorized', () => {

--- a/src/app/restricted-access/restricted-access.component.ts
+++ b/src/app/restricted-access/restricted-access.component.ts
@@ -32,6 +32,7 @@ import { AuthorizationDataService } from '../core/data/feature-authorization/aut
 import { FeatureID } from '../core/data/feature-authorization/feature-id';
 import { RemoteData } from '../core/data/remote-data';
 import { HardRedirectService } from '../core/services/hard-redirect.service';
+import { ServerResponseService } from '../core/services/server-response.service';
 import { redirectOn4xx } from '../core/shared/authorized.operators';
 import { Bitstream } from '../core/shared/bitstream.model';
 import { FileService } from '../core/shared/file.service';
@@ -42,7 +43,7 @@ import {
 } from '../shared/empty.util';
 
 /**
- * This component representing the `Restricted Access` DSpace page.
+ * This component represents the `Restricted Access` DSpace page.
  */
 @Component({
   selector: 'ds-restricted-access',
@@ -77,6 +78,7 @@ export class RestrictedAccessComponent implements OnInit {
     private translateService: TranslateService,
     private datePipe: DatePipe,
     private location: Location,
+    private responseService: ServerResponseService,
   ) {
   }
 
@@ -124,6 +126,8 @@ export class RestrictedAccessComponent implements OnInit {
 
         if (isLoggedIn) {
           // This is a logged in user
+          // Set 403 Forbidden response status code for logged-in users without download permission
+          this.responseService.setForbidden();
           header$ = this.translateService.get('bitstream.restricted-access.user.forbidden.header', {});
 
           if (bitstream && bitstream.metadata['dc.title'] &&  bitstream.metadata['dc.title'][0] && bitstream.metadata['dc.title'][0].value) {
@@ -136,6 +140,8 @@ export class RestrictedAccessComponent implements OnInit {
           }
         } else {
           // This is an anonymous user
+          // Set 401 Unauthorized response status code for anonymous users
+          this.responseService.setUnauthorized();
           [header$, message$] = this.configureAnonymous(bitstream);
         }
 
@@ -164,7 +170,7 @@ export class RestrictedAccessComponent implements OnInit {
       );
     } else {
       // Reach this branch when embargoRestriction is "NONE", but there is some
-      // other restriction, such as a "Campus" IP address group restiction.
+      // other restriction, such as a "Campus" IP address group restriction.
       message$ = this.translateService.get('bitstream.restricted-access.anonymous.forbidden.message', {});
     }
 
@@ -172,10 +178,10 @@ export class RestrictedAccessComponent implements OnInit {
   }
 
   /**
-   * Returns true if the given String represents a valid date, false otherise.
+   * Returns true if the given String represents a valid date, false otherwise.
    *
    * @param str the String to check.
-   * @true if the given String represents a valid date, false otherise.
+   * @returns true if the given String represents a valid date, false otherwise.
    */
   private isValidDate(str: string): boolean {
     // Expected date is in yyyy-MM-dd format.

--- a/src/app/restricted-access/restricted-access.component.ts
+++ b/src/app/restricted-access/restricted-access.component.ts
@@ -5,8 +5,11 @@ import {
 } from '@angular/common';
 import {
   Component,
+  DestroyRef,
+  inject,
   OnInit,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   ActivatedRoute,
   Router,
@@ -18,6 +21,7 @@ import {
 import {
   BehaviorSubject,
   combineLatest as observableCombineLatest,
+  EMPTY,
   filter,
   map,
   Observable,
@@ -68,6 +72,8 @@ export class RestrictedAccessComponent implements OnInit {
   bitstreamRD$: Observable<RemoteData<Bitstream>>;
   bitstream$: Observable<Bitstream>;
 
+  private destroyRef = inject(DestroyRef);
+
   constructor(
     private route: ActivatedRoute,
     protected router: Router,
@@ -112,15 +118,17 @@ export class RestrictedAccessComponent implements OnInit {
               return [isAuthorized, isLoggedIn, bitstream, fileLink];
             }));
         } else {
-          return [[isAuthorized, isLoggedIn, bitstream, '']];
+          return observableOf([isAuthorized, isLoggedIn, bitstream, ''] as [boolean, boolean, Bitstream, string]);
         }
       }),
-    ).subscribe(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
-      if (isAuthorized && isNotEmpty(fileLink)) {
-        // This shouldn't happen, as the download is authorized, and the file link is available, so just redirect to
-        // actual download page.
-        this.hardRedirectService.redirect(fileLink);
-      } else {
+      switchMap(([isAuthorized, isLoggedIn, bitstream, fileLink]: [boolean, boolean, Bitstream, string]) => {
+        if (isAuthorized && isNotEmpty(fileLink)) {
+          // This shouldn't happen, as the download is authorized, and the file link is available, so just redirect to
+          // actual download page.
+          this.hardRedirectService.redirect(fileLink);
+          return EMPTY;
+        }
+
         let header$: Observable<string>;
         let message$: Observable<string>;
 
@@ -130,7 +138,7 @@ export class RestrictedAccessComponent implements OnInit {
           this.responseService.setForbidden();
           header$ = this.translateService.get('bitstream.restricted-access.user.forbidden.header', {});
 
-          if (bitstream && bitstream.metadata['dc.title'] &&  bitstream.metadata['dc.title'][0] && bitstream.metadata['dc.title'][0].value) {
+          if (bitstream && bitstream.metadata['dc.title'] && bitstream.metadata['dc.title'][0] && bitstream.metadata['dc.title'][0].value) {
             const filename = bitstream.metadata['dc.title'][0].value;
             message$ = this.translateService.get(
               'bitstream.restricted-access.user.forbidden.with_file.message', { 'filename': filename });
@@ -145,11 +153,12 @@ export class RestrictedAccessComponent implements OnInit {
           [header$, message$] = this.configureAnonymous(bitstream);
         }
 
-        zip(header$, message$).subscribe(([header, message]) => {
-          this.restrictedAccessHeader.next(header);
-          this.restrictedAccessMessage.next(message);
-        });
-      }
+        return zip(header$, message$);
+      }),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(([header, message]: [string, string]) => {
+      this.restrictedAccessHeader.next(header);
+      this.restrictedAccessMessage.next(message);
     });
   }
 


### PR DESCRIPTION
Corrects Google Search reports of "Soft 404" errors for the "Restricted Access" pages returned when a DSpace bitstream is embargoed or otherwise not available but returning either "401 Unauthorized" for anonymous users, or "403 Forbidden" for unauthorized users.

This change only affects the Angular server-side rendering (SSR) functionality that is triggered by bots -- regular users will still see a "Restricted Access" page with a 200 OK response.

https://umd-dit.atlassian.net/browse/LIBDRUM-1005
