### PR TITLE
LIBDRUM-1018. Ensure UMD customization is part of default access group

### DIFF
--- a/src/robots.txt.ejs
+++ b/src/robots.txt.ejs
@@ -18,7 +18,6 @@ Disallow: /profile
 Disallow: /workflowitems
 # Crawlers should be able to access entity pages, but not the facet search links present on entity pages
 Disallow: /entities/*?f
-
 # Optionally uncomment the following line ONLY if sitemaps are working
 # and you have verified that your site is being indexed correctly.
 # UMD Customization


### PR DESCRIPTION
Ensures that the UMD customization enabling the rule forbidding crawling of `/browse/*` endpoints is part of the default access group by removing the blank line that separates the rule from the rest of the group.

In a "robots.txt" file, any blank line ends a group, so this was done to ensure that this rule is part of the ruleset used by all crawlers.

https://umd-dit.atlassian.net/browse/LIBDRUM-1018
