### PR TITLE
LIBDRUM-912. Added "External Link to Data Files" to simple item page

### DIFF
--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -7200,6 +7200,8 @@
 
   "item.page.doi": "DRUM DOI",
 
+  "item.page.externalDataFilesLink": "External Link to Data Files",
+
   "item.page.publicationLink": "Publication or External Link",
 
   "item.page.publicationLink.datasetOrSoftware": "Related Publication Link",

--- a/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/src/themes/drum/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -41,6 +41,12 @@
       [label]="publicationLinkLabelI18nKey">
     </ds-item-page-uri-field>
 
+    <!-- External Link to Data Files -->
+    <ds-item-page-uri-field [item]="object"
+      [fields]="['dc.relation.uri']"
+      [label]="'item.page.externalDataFilesLink'">
+    </ds-item-page-uri-field>
+
     <!-- Date -->
     <ds-item-page-date-field [item]="object"></ds-item-page-date-field>
 


### PR DESCRIPTION
Added an "External Link to Data Files" field in the left column of the simple item page, which displays the value of the "dc.relation.uri" metadata field.

https://umd-dit.atlassian.net/browse/LIBDRUM-912
