### PR TITLE
LIBDRUM-909. Fix race condition in validation error display after deposit

### DIFF
--- a/docs/DrumAngularCustomizations.md
+++ b/docs/DrumAngularCustomizations.md
@@ -80,3 +80,22 @@ would successfully complete:
 
 * Commented out the "codecov" job, because UMD does not have an appropriate key
   for uploading the results to codecov.io.
+
+## Change to Submission Form Validation Handling
+
+The "updateForm" method in the "SubmissionSectionFormComponent" class
+(src/app/submission/sections/form/section-form.component.ts) has been
+modified to clear the form validation errors held by Angular when
+receiving a form update from the back-end.
+
+This change is intended to fix an issue (see LIBDRUM-909) in which submitting
+a form without all the required fields populated would only show a brief
+"flash" of the validation errors, and then not show GUI validation
+warnings on all affected fields. This is apparently caused by a race condition
+between the Angular validation handling, and a page refresh triggered by the
+DSpace backend response.
+
+It is unclear whether this is the optimal fix, so it has not been submitted
+upstream to DSpace. Also, DSpace has been working on various similar fixes, so
+the changes in this class should be re-evaluated on upgrades, and
+removed if possible.

--- a/src/app/submission/sections/form/section-form.component.ts
+++ b/src/app/submission/sections/form/section-form.component.ts
@@ -370,6 +370,20 @@ export class SubmissionSectionFormComponent extends SectionModelComponent {
         this.isUpdating = true;
         this.formModel = null;
         this.cdr.detectChanges();
+        // UMD Customization
+        // Clear errors before calling initForm.
+        // This is needed because this code path may be called multiple times,
+        // and checksForErrors does a no-op (essentially clearing the
+        // validation errors) if the "this.sectionData.errorsToShow" hasn't
+        // changed.
+        // Clearing the "errorsToShow" ensures that checksForErrors actually
+        // shows the errors, no matter how many times this code block is called.
+        //
+        // Note: Future DSpace changes may eliminate the need for this change,
+        // so it should be checked when doing DSpace upgrades, and removed,
+        // if possible.
+        this.sectionData.errorsToShow = [];
+        // End UMD Customization
         this.initForm(sectionData, errors, sectionState.serverValidationErrors);
         this.checksForErrors(errors);
         this.isUpdating = false;


### PR DESCRIPTION
When depositing with missing required fields, the backend returns errors
that trigger a form re-initialization via hasMetadataEnrichment(). This
causes checksForErrors() to be called multiple times concurrently. The
first call correctly marks form controls as touched, but initForm()
then rebuilds the controls, wiping their touched state. The second call
is skipped by the isEqual() guard in checkSectionErrors() because
this.sectionData.errorsToShow was already updated by the first call,
so markAsTouched() is never re-applied to the rebuilt controls.

This fix resets this.sectionData.errorsToShow to [] before calling
initForm() in the hasMetadataEnrichment branch of updateForm(), so the
second checksForErrors() call treats the errors as new and re-applies
them to the rebuilt form controls.

Co-authored-by: Perplexity AI <noreply@perplexity.ai>
https://umd-dit.atlassian.net/browse/LIBDRUM-909